### PR TITLE
fix: mark 4:3 recordings as stretched

### DIFF
--- a/.trellis/spec/backend/wails-bindings.md
+++ b/.trellis/spec/backend/wails-bindings.md
@@ -355,8 +355,8 @@ launch_resolution: "16:9" | "4:3" | "4:3_1280x960";
 
 - `launch_resolution` allowed values:
   - `16:9`: launch without explicit 4:3 width/height override.
-  - `4:3`: launch with `-w 1440 -h 1080`.
-  - `4:3_1280x960`: launch with `-w 1280 -h 960`.
+  - `4:3`: launch with `-w 1440 -h 1080`; recording output is tagged with FFmpeg `-aspect 16:9` for stretched playback.
+  - `4:3_1280x960`: launch with `-w 1280 -h 960`; recording output is tagged with FFmpeg `-aspect 16:9` for stretched playback.
 - Default is `4:3`.
 - Existing `4:3` config values must continue to mean `1440x1080`; do not repurpose this value for lower 4:3 resolutions.
 - Frontend option labels are i18n keys under `main.settings.*`; per frontend rules, new labels are added to `zh-CN.json` only.
@@ -371,6 +371,7 @@ launch_resolution: "16:9" | "4:3" | "4:3_1280x960";
 
 - Good: selecting `4:3_1280x960` persists that exact value and launches with `-w 1280 -h 960`.
 - Base: selecting `4:3` preserves backward-compatible `-w 1440 -h 1080` behavior.
+- Base: 4:3 recording output uses display aspect metadata for 16:9 stretched playback; do not add pixel scaling unless a separate output-size feature requires it.
 - Bad: changing the meaning of `4:3` to `1280x960`, which silently alters existing user configs.
 
 ### 6. Tests Required
@@ -378,6 +379,7 @@ launch_resolution: "16:9" | "4:3" | "4:3_1280x960";
 - `internal/config`: `ApplyDefaults` preserves every supported `launch_resolution` value.
 - `internal/app`: `SaveClipSettings` and `GetClipSettings` round-trip each supported launch resolution value.
 - `internal/app`: `buildHLAECommandLine` maps `4:3` to `1440x1080`, maps `4:3_1280x960` to `1280x960`, and leaves `16:9` without 4:3 dimensions.
+- `internal/clipsjson`: generated FFmpeg recording settings include `-aspect 16:9` for `4:3` and `4:3_1280x960`, and omit it for `16:9` / empty values.
 - Frontend: `cd frontend && npm run build` must pass so the shared TypeScript union and settings options stay aligned.
 
 ### 7. Wrong vs Correct

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@
 - `GetClipSettings` / `SaveClipSettings` 字段约定新增：`edit_fps`（范围 `24..240`，默认 `60`）与 `edit_quality`（`standard|high|ultra`，默认 `high`）
 - `GetClipSettings` / `SaveClipSettings` 字段约定新增：`record_quality`（`standard|high|ultra`，默认 `high`；软件编码映射到 `crf`，硬件编码映射到 `qp` / `q:v`）
 - `GetClipSettings` / `SaveClipSettings` 字段约定更新：`video_preset` 取值 `auto|c1|n1|a1|i1`（默认 `auto`；`auto` 表示按 FFmpeg 探测能力自动选择）
-- `GetClipSettings` / `SaveClipSettings` 字段约定更新：`launch_resolution` 取值 `16:9|4:3|4:3_1280x960`（默认 `4:3`；`4:3` 表示 `1440x1080`，`4:3_1280x960` 表示 `1280x960`）
+- `GetClipSettings` / `SaveClipSettings` 字段约定更新：`launch_resolution` 取值 `16:9|4:3|4:3_1280x960`（默认 `4:3`；`4:3` 表示 `1440x1080`，`4:3_1280x960` 表示 `1280x960`；两种 4:3 录制输出均通过 FFmpeg `-aspect 16:9` 标记为 stretched playback）
 - `GetClipSettings` / `SaveClipSettings` 字段约定新增：`hide_all_ui`（默认 `false`；开启时生成插件 JSON bootstrap 写入 `cl_draw_only_deathnotices 1`，关闭时不写入该命令）
 - `GeneratePluginJSON`
 - `GeneratePluginJSON` 支持可选参数 `record_victim_view`（开启后按片段生成“击杀者视角 -> 被害者视角”连续序列）

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -30,7 +30,7 @@
 - Must：`gameinfo.gi` 健康状态以 `GetGameInfoHealth` / `RepairGameInfo` 返回值为来源；前端不得自行读取或推断 `gameinfo.gi` 文件内容。
 - Must：`ClipSettings.video_preset` 需与后端保持一致，允许值 `auto|c1|n1|a1|i1`（`auto` 代表使用后端探测到的 FFmpeg 能力自动选择编码）。
 - Must：`ClipSettings.record_quality` 需与后端保持一致，允许值 `standard|high|ultra`（默认 `high`；软件编码映射到 CRF，硬件编码映射到 QP / `q:v`）。
-- Must：`ClipSettings.launch_resolution` 需与后端保持一致，允许值 `16:9|4:3|4:3_1280x960`（`4:3` 代表 `1440x1080`，`4:3_1280x960` 代表 `1280x960`）。
+- Must：`ClipSettings.launch_resolution` 需与后端保持一致，允许值 `16:9|4:3|4:3_1280x960`（`4:3` 代表 `1440x1080`，`4:3_1280x960` 代表 `1280x960`；两种 4:3 录制输出均由后端 FFmpeg 参数标记为 16:9 stretched playback）。
 - Must：`ClipSettings.hide_all_ui` 需与后端保持一致，默认 `false`；开启时生成插件 JSON bootstrap 写入 `cl_draw_only_deathnotices 1`，关闭时不写入该命令。
 - Must：调用 `GeneratePluginJSONBatchAndLaunchHLAE` 时允许传递可选 `debug.keep_intermediate_files`，用于控制是否保留录制中间产物（仅会话级生效）。
 - Must Not：在前端新增与后端冲突的“本地自定义状态枚举”替代后端状态。

--- a/internal/app/plugin_generate.go
+++ b/internal/app/plugin_generate.go
@@ -492,6 +492,7 @@ func (a *App) generatePluginJSONInternal(
 		HideAllUI:                 clipSettings.HideAllUI,
 		ForcePerPassVoiceCommands: hasVoiceOverride,
 		ForcePerPassXrayCommands:  hasSpecShowXrayOverride,
+		LaunchResolution:          cfg.LaunchResolution,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/internal/clipsjson/builder.go
+++ b/internal/clipsjson/builder.go
@@ -76,6 +76,7 @@ type BuildOptions struct {
 	HideAllUI                 bool
 	ForcePerPassVoiceCommands bool
 	ForcePerPassXrayCommands  bool
+	LaunchResolution          string
 }
 
 type BuildResult struct {
@@ -175,7 +176,7 @@ func Build(items []Item, opts BuildOptions) (*BuildResult, error) {
 	if recordFPS <= 0 {
 		recordFPS = 60
 	}
-	videoPreset, ffmpegParams, err := buildFFmpegParams(opts.VideoPreset, opts.RecordQuality)
+	videoPreset, ffmpegParams, err := buildFFmpegParams(opts.VideoPreset, opts.RecordQuality, opts.LaunchResolution)
 	if err != nil {
 		return nil, err
 	}
@@ -638,7 +639,7 @@ func xrayCommandValue(enableSpecShowXray bool) int {
 	return -1
 }
 
-func buildFFmpegParams(preset string, quality string) (string, string, error) {
+func buildFFmpegParams(preset string, quality string, launchResolution string) (string, string, error) {
 	videoPreset, _, err := ffmpegprofile.HLAEProfileByID(preset)
 	if err != nil {
 		return "", "", err
@@ -647,7 +648,19 @@ func buildFFmpegParams(preset string, quality string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+	if shouldStretchFourThreeRecording(launchResolution) {
+		params += " -aspect 16:9"
+	}
 	return videoPreset, params, nil
+}
+
+func shouldStretchFourThreeRecording(launchResolution string) bool {
+	switch strings.TrimSpace(launchResolution) {
+	case "4:3", "4:3_1280x960":
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizePathForCommand(path string) string {

--- a/internal/clipsjson/builder_test.go
+++ b/internal/clipsjson/builder_test.go
@@ -441,6 +441,44 @@ func TestBuild_AppliesRecordQualityToHardwarePreset(t *testing.T) {
 	assertHasActionContaining(t, bootstrap, "-qp 10")
 }
 
+func TestBuild_AddsDisplayAspectForFourThreeLaunchResolution(t *testing.T) {
+	tests := []struct {
+		name             string
+		launchResolution string
+		wantAspect       bool
+	}{
+		{name: "4:3 1440x1080", launchResolution: "4:3", wantAspect: true},
+		{name: "4:3 1280x960", launchResolution: "4:3_1280x960", wantAspect: true},
+		{name: "16:9", launchResolution: "16:9", wantAspect: false},
+		{name: "empty", launchResolution: "", wantAspect: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Build([]Item{{
+				Kill: demo.ClipKill{ID: "k1", Tick: 200, KillerSlot: 7},
+			}}, BuildOptions{
+				TickRate:          64,
+				KillerPreSeconds:  1,
+				KillerPostSeconds: 1,
+				RecordFPS:         60,
+				VideoPreset:       "c1",
+				RecordOutputDir:   `D:/clips/output`,
+				LaunchResolution:  tt.launchResolution,
+			})
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			bootstrap := result.Sequences[0].Actions
+			if tt.wantAspect {
+				assertHasActionContaining(t, bootstrap, "-aspect 16:9")
+				return
+			}
+			assertNoActionContaining(t, bootstrap, "-aspect 16:9")
+		})
+	}
+}
+
 func assertHasAction(t *testing.T, actions []Action, cmd string) {
 	t.Helper()
 	for _, action := range actions {
@@ -487,6 +525,15 @@ func assertHasActionContaining(t *testing.T, actions []Action, needle string) {
 		}
 	}
 	t.Fatalf("action containing %q not found in %#v", needle, actions)
+}
+
+func assertNoActionContaining(t *testing.T, actions []Action, needle string) {
+	t.Helper()
+	for _, action := range actions {
+		if strings.Contains(action.Cmd, needle) {
+			t.Fatalf("unexpected action containing %q found: %#v", needle, action)
+		}
+	}
 }
 
 func takeName(index int) string {


### PR DESCRIPTION
Add FFmpeg display aspect metadata for 4:3 HLAE recording modes so 1440x1080 and 1280x960 captures play back as 16:9 stretched output.

Based on PR #11 commit 22458d4 by zzz090758.