### PR TITLE
chore: release v2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,6 @@
 - [Purple-CSGO](https://github.com/Purple-CSGO/)
 - [wails](https://wails.io/)
 - [cs-demo-manager](https://github.com/akiver/cs-demo-manager)
-
+- [POV HUD](https://www.youtube.com/watch?v=vB1b11rRDzI)
+- [gh-proxy](https://gh-proxy.com/)
 ---

--- a/internal/changelog/notes/v2.0.3.md
+++ b/internal/changelog/notes/v2.0.3.md
@@ -1,0 +1,36 @@
+## 中文
+
+### 新增
+
+- 启动时检测 CS2 `gameinfo.gi` 文件是否正常，修复可能影响游戏正常启动的异常
+- 整局 POV 录制：从回合开始到回合结束/被跟踪玩家阵亡的整局 POV自动化录制
+- 录制设置新增 POV HUD 模拟游戏第一视角
+- 录制设置新增天空盒变黑开关
+- 录制设置新增击杀信息留存时间设置
+- 录制设置新增屏蔽所有击杀信息开关
+- 录制服务异常断开时自动重试，具备有限次指数退避
+- 更新后首次进入主界面时弹窗展示当前版本更新日志，同版本关闭后不再重复
+
+### 修复
+
+- 软件自更新可用时，正确阻断启动流程，不再同时触发组件安装
+- 4:3 分辨率录制输出标记为拉伸16:9画面
+
+
+## English
+
+### Added
+
+- GameInfo health check and repair: detect anomalies that may prevent CS2 from launching normally
+- Full-round POV recording: automatically record from round start to round end or tracked player death
+- Recording settings: POV HUD to simulate first-person in-game view
+- Recording settings: sky blackout toggle
+- Recording settings: kill feed lifetime configuration
+- Recording settings: kill feed block toggle
+- Auto-retry with bounded exponential backoff when recording service disconnects
+- Changelog modal shown on first launch after update; dismissed once per version
+
+### Fixed
+
+- Self-update blocking startup flow correctly prevents concurrent component installation
+- 4:3 recordings are properly marked as stretched 16:9 playback

--- a/wails.json
+++ b/wails.json
@@ -1,13 +1,13 @@
 {
   "name": "cs2-highlight-tool-v2",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "outputfilename": "cs2-highlight-tool-v2",
   "frontend:install": "npm install",
   "frontend:build": "npm run build",
   "frontend:dev:watcher": "npm run dev",
   "frontend:dev:serverUrl": "auto",
   "info": {
-    "productVersion": "2.0.2"
+    "productVersion": "2.0.3"
   },
   "author": {
     "name": "hkslover",


### PR DESCRIPTION
## Summary
- Bump app version to **2.0.3** (`wails.json` `version` & `info.productVersion`)
- Add `internal/changelog/notes/v2.0.3.md` bilingual release notes (will be shown by the post-update changelog modal)
- Credit POV HUD and gh-proxy in `README.md`

## Release notes (v2.0.3)

**新增**
- 启动时检测 CS2 `gameinfo.gi` 文件健康，修复可能阻止 CS2 正常启动的异常
- 整局 POV 录制：从回合开始到回合结束 / 被跟踪玩家阵亡的自动化 POV 录制
- 录制设置：POV HUD 模拟游戏第一视角
- 录制设置：天空盒变黑开关
- 录制设置：击杀信息留存时间设置
- 录制设置：屏蔽所有击杀信息开关
- 录制服务异常断开时自动重试（有限次指数退避）
- 更新后首次进入主界面弹窗展示当前版本更新日志（同版本关闭后不再重复）

**修复**
- 软件自更新可用时正确阻断启动流程，不再同时触发组件安装
- 4:3 分辨率录制输出标记为拉伸 16:9 画面

## Release flow
After this PR is merged into `main`:
1. `git checkout main && git pull`
2. `git tag v2.0.3 && git push origin v2.0.3`
3. The `Release Windows` workflow (`.github/workflows/release-windows.yml`) builds the Windows binary and publishes the GitHub Release.

## Test plan
- [ ] CI lint/build (if any) passes on this branch
- [ ] After merge + tag push, verify `Release Windows` workflow succeeds
- [ ] Verify post-update changelog modal renders v2.0.3 notes on first launch after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)