### PR TITLE
docs: complete v2.0.4 changelog

### DIFF
--- a/internal/changelog/notes/v2.0.4.md
+++ b/internal/changelog/notes/v2.0.4.md
@@ -2,27 +2,47 @@
 
 ### 新增
 
-- 录制设置新增 POV 雷达开关及提示示意图
-- 将队伍语音设置整合到配置列表，并补充相关多语言文本
-- 增强生产 WebSocket 断线恢复与诊断能力
+- 设置新增 POV 雷达，模拟 POV视角
+- 录制设置改为支持搜索和分页的“配置”列表
+- 新增独立的“关闭云层”开关，与“天空变黑”分别控制
+- 调试模式支持选择自定义插件 DLL，仅对当前会话生效，不修改持久化配置
+- 制作发生 WebSocket、队列或启动错误时，可导出包含主程序和插件信息的制作诊断日志
+
+### 优化
+
+- 击杀者和受害者片段的前后时间窗口上限统一扩展至 20 秒
+- 剪辑录制跳转增加预定位缓冲，减少慢速机器上的 seek 抖动
+- 制作 WebSocket 改用操作系统分配的本机动态端口，并自动传递给 HLAE/插件，减少固定端口冲突
+- 增强制作 WebSocket 的心跳检测、断线分类、短时断线恢复、事件记录和故障报告能力
 
 ### 修复
 
-- 修复剪辑转场过程中的音视频同步问题
-- 提升生产流程生命周期和配置持久化的可靠性
-- 更新应用版本至 2.0.4
+- 修复多片段转场合并时的音视频不同步，并改为单条滤镜链完成转场和编码
+- 提升制作流程生命周期、配置持久化、配置文件原子写入和并发更新的可靠性
+- 修复下载内容被截断时仍可能被判定为成功的问题
+- 修复制作失败时误清理原始素材、崩溃残留的 `gameinfo.gi` 备份未恢复，以及批量制作路径不一致的问题
 
 
 ## English
 
 ### Added
 
-- Recording settings now include a POV radar toggle and hint illustration
-- Team voice settings are integrated into the configuration list with updated translations
-- Improved production WebSocket recovery and diagnostics
+- Added a POV Radar recording toggle, disabled by default, with a beta warning and demonstration image
+- Recording settings are now presented in a searchable, paginated “Options” list with a fixed page size of 8; team voice is included in the list
+- Added an independent “Disable clouds” toggle separate from skybox blackout
+- Debug mode now supports selecting a custom plugin DLL for the current session without changing persisted settings
+- Added production diagnostics export when a WebSocket, queue, or launch error occurs, including host and plugin information
+
+### Improved
+
+- Increased the maximum pre- and post-event windows for killer and victim clips to 20 seconds
+- Added a pre-seek settling buffer to reduce seek jitter on slower machines during clip recording
+- Production WebSocket now uses an OS-assigned local port and passes it to HLAE/the plugin, reducing fixed-port conflicts
+- Improved production WebSocket heartbeats, disconnect classification, short-disconnect recovery, event logging, and incident reports
 
 ### Fixed
 
-- Fixed audio/video synchronization during clip transitions
-- Improved production lifecycle and configuration persistence reliability
-- Updated the application version to 2.0.4
+- Fixed audio/video desynchronization when merging clips with transitions by composing transitions in a single filter graph and encode
+- Improved production lifecycle handling, configuration persistence, atomic config writes, and concurrent updates
+- Fixed truncated downloads being incorrectly treated as successful
+- Fixed raw materials being removed after failed production, stale `gameinfo.gi` backups not being restored after a crash, and inconsistent paths in batch production


### PR DESCRIPTION
## Summary

- Complete the Chinese and English v2.0.4 changelog based on the changes after v2.0.3.
- Document the new recording settings, POV radar, cloud controls, debug plugin override, WebSocket diagnostics/recovery, timing improvements, and reliability fixes.

## Validation

- `go test ./internal/changelog`
- `git diff --check`
