### PR TITLE
fix: recover produce files and propagate record quality

### DIFF
--- a/internal/app/app_clips_test.go
+++ b/internal/app/app_clips_test.go
@@ -393,6 +393,36 @@ func TestGeneratePluginJSON_ContainsMirvRecordingCommands(t *testing.T) {
 	}
 }
 
+func TestGeneratePluginJSON_PassesRecordQualityToFFmpegBootstrap(t *testing.T) {
+	exeDir := t.TempDir()
+	app := &App{exeDir: exeDir}
+	if _, err := app.SaveClipSettings(ClipSettings{
+		RecordQuality: "ultra",
+		VideoPreset:   "n1",
+	}); err != nil {
+		t.Fatalf("SaveClipSettings: %v", err)
+	}
+
+	demoPath := writeDemoFile(t)
+	if _, err := app.GeneratePluginJSON(GeneratePluginJSONRequest{
+		DemoPath: demoPath,
+		TickRate: 64,
+		SelectedItems: []SelectedClipItem{
+			{Kill: demo.ClipKill{ID: "k1", Tick: 200, KillerSlot: 7}, IncludeVictim: false},
+		},
+	}); err != nil {
+		t.Fatalf("GeneratePluginJSON: %v", err)
+	}
+
+	sequences := readGeneratedSequences(t, demoPath+".json")
+	for _, action := range sequences[0].Actions {
+		if strings.Contains(action.Cmd, "mirv_streams settings add ffmpeg n1") && strings.Contains(action.Cmd, "-qp 10") {
+			return
+		}
+	}
+	t.Fatalf("record quality was not passed to the generated ffmpeg bootstrap: %#v", sequences[0].Actions)
+}
+
 func TestGeneratePluginJSON_EmitsTakePlans(t *testing.T) {
 	exeDir := t.TempDir()
 	app := &App{exeDir: exeDir}

--- a/internal/app/plugin_generate.go
+++ b/internal/app/plugin_generate.go
@@ -486,6 +486,7 @@ func (a *App) generatePluginJSONInternal(
 		AutoAddVictimView:  cfg.AutoAddVictimView,
 		EnableVoice:        actionSettings.EnableVoiceIndices && actionSettings.EnableVoiceIndicesH,
 		RecordFPS:          cfg.RecordFPS,
+		RecordQuality:      cfg.RecordQuality,
 		VideoPreset:        cfg.VideoPreset,
 		RecordOutputDir:    a.fixedRecordOutputDir(),
 		EnableSpecShowXray: cfg.EnableSpecShowXray,

--- a/internal/app/produce_gameconfig.go
+++ b/internal/app/produce_gameconfig.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	produceGameInfoBackupSuffix  = ".cs2ht_produce.bak"
-	producePluginDLLBackupSuffix = ".cs2ht_plugin.bak"
+	produceGameInfoBackupSuffix   = ".cs2ht_produce.bak"
+	producePluginDLLBackupSuffix  = ".cs2ht_plugin.bak"
+	producePluginDLLMissingMarker = "cs2-highlight-tool:plugin-dll-target-missing:v1\n"
 )
 
 type gameInfoSessionState struct {
@@ -138,13 +139,88 @@ func (a *App) recoverStaleGameInfoBackup(gameInfoPath string) error {
 		}
 		return fmt.Errorf("读取残留 gameinfo 备份失败: %w", err)
 	}
-	if err := copyFile(backupPath, gameInfoPath); err != nil {
-		return fmt.Errorf("恢复残留 gameinfo.gi 失败: %w", err)
+	backupBytes, err := os.ReadFile(backupPath)
+	if err != nil {
+		return fmt.Errorf("读取残留 gameinfo 备份失败: %w", err)
+	}
+	currentBytes, err := os.ReadFile(gameInfoPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("读取当前 gameinfo.gi 失败: %w", err)
+		}
+		// There is no live content to preserve if the file disappeared.
+		if err := copyFile(backupPath, gameInfoPath); err != nil {
+			return fmt.Errorf("恢复残留 gameinfo.gi 失败: %w", err)
+		}
+	} else {
+		recovered, changed := removeStaleInjectedSearchPaths(string(currentBytes), string(backupBytes))
+		if changed {
+			mode := os.FileMode(0644)
+			if info, statErr := os.Stat(gameInfoPath); statErr == nil {
+				mode = info.Mode().Perm()
+			}
+			if err := os.WriteFile(gameInfoPath, []byte(recovered), mode); err != nil {
+				return fmt.Errorf("恢复残留 gameinfo.gi 失败: %w", err)
+			}
+		}
 	}
 	if err := os.Remove(backupPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("清理残留 gameinfo 备份失败: %w", err)
 	}
 	return nil
+}
+
+// removeStaleInjectedSearchPaths removes only extra known search-path entries
+// that the previous produce session could have added. Entries already present
+// in the backup are kept, preserving pre-existing user/Steam configuration.
+func removeStaleInjectedSearchPaths(current string, backup string) (string, bool) {
+	backupCounts := make(map[string]int, len(knownInjectedSearchPaths()))
+	currentCounts := make(map[string]int, len(knownInjectedSearchPaths()))
+	for _, searchPath := range knownInjectedSearchPaths() {
+		backupCounts[searchPath] = countSearchPathEntries(backup, searchPath)
+		currentCounts[searchPath] = countSearchPathEntries(current, searchPath)
+	}
+
+	removeCounts := make(map[string]int, len(knownInjectedSearchPaths()))
+	for _, searchPath := range knownInjectedSearchPaths() {
+		// One produce session can add at most one entry for each path. Remove
+		// only that one so additional entries written by the user/Steam survive.
+		if currentCounts[searchPath] > backupCounts[searchPath] {
+			removeCounts[searchPath] = 1
+		}
+	}
+
+	changed := false
+	lines := strings.Split(current, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		removed := false
+		for _, searchPath := range knownInjectedSearchPaths() {
+			if removeCounts[searchPath] > 0 && producegame.HasSearchPath(line, searchPath) {
+				removeCounts[searchPath]--
+				changed = true
+				removed = true
+				break
+			}
+		}
+		if !removed {
+			kept = append(kept, line)
+		}
+	}
+	if !changed {
+		return current, false
+	}
+	return strings.Join(kept, "\n"), true
+}
+
+func countSearchPathEntries(content string, searchPath string) int {
+	count := 0
+	for _, line := range strings.Split(content, "\n") {
+		if producegame.HasSearchPath(line, searchPath) {
+			count++
+		}
+	}
+	return count
 }
 
 // preparePovForProduce drops the embedded pov.vpk into csgo/pov.vpk when the
@@ -253,6 +329,9 @@ func (a *App) preparePluginDLLForProduce() (retErr error) {
 	backupPath := ""
 	pluginDirCreated := false
 	binDirCreated := false
+	if err := a.recoverStalePluginDLLBackup(targetPath); err != nil {
+		return err
+	}
 
 	defer func() {
 		if retErr == nil {
@@ -260,8 +339,7 @@ func (a *App) preparePluginDLLForProduce() (retErr error) {
 		}
 		if modified {
 			if strings.TrimSpace(backupPath) != "" {
-				_ = copyFileWithReplace(backupPath, targetPath)
-				_ = os.Remove(backupPath)
+				_ = restorePluginDLLBackup(backupPath, targetPath)
 			} else if strings.TrimSpace(targetPath) != "" {
 				_ = os.Remove(targetPath)
 			}
@@ -310,6 +388,11 @@ func (a *App) preparePluginDLLForProduce() (retErr error) {
 			}
 		} else if !os.IsNotExist(targetErr) {
 			return fmt.Errorf("读取目标插件 DLL 失败: %w", targetErr)
+		} else {
+			backupPath = targetPath + producePluginDLLBackupSuffix
+			if err := os.WriteFile(backupPath, []byte(producePluginDLLMissingMarker), 0644); err != nil {
+				return fmt.Errorf("记录目标插件 DLL 缺失状态失败: %w", err)
+			}
 		}
 
 		if err := copyFileWithReplace(pluginSourcePath, targetPath); err != nil {
@@ -328,6 +411,65 @@ func (a *App) preparePluginDLLForProduce() (retErr error) {
 		pluginDirCreated: pluginDirCreated,
 	}
 	a.produceStateMu.Unlock()
+	return nil
+}
+
+func (a *App) recoverStalePluginDLLBackup(targetPath string) error {
+	targetPath = strings.TrimSpace(targetPath)
+	if targetPath == "" {
+		return nil
+	}
+
+	a.produceStateMu.Lock()
+	activeState := a.produceState.pluginDLL
+	a.produceStateMu.Unlock()
+	backupPath := targetPath + producePluginDLLBackupSuffix
+	if activeState.modified &&
+		samePath(activeState.targetPath, targetPath) &&
+		samePath(activeState.backupPath, backupPath) {
+		return nil
+	}
+
+	backupBytes, err := os.ReadFile(backupPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("读取残留插件 DLL 备份失败: %w", err)
+	}
+	if string(backupBytes) == producePluginDLLMissingMarker {
+		if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("移除残留注入插件 DLL 失败: %w", err)
+		}
+	} else if err := copyFileWithReplace(backupPath, targetPath); err != nil {
+		return fmt.Errorf("恢复残留插件 DLL 失败: %w", err)
+	}
+	if err := os.Remove(backupPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("清理残留插件 DLL 备份失败: %w", err)
+	}
+	return nil
+}
+
+func restorePluginDLLBackup(backupPath string, targetPath string) error {
+	backupPath = strings.TrimSpace(backupPath)
+	targetPath = strings.TrimSpace(targetPath)
+	if backupPath == "" || targetPath == "" {
+		return fmt.Errorf("插件 DLL 恢复路径为空")
+	}
+	backupBytes, err := os.ReadFile(backupPath)
+	if err != nil {
+		return err
+	}
+	if string(backupBytes) == producePluginDLLMissingMarker {
+		if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	} else if err := copyFileWithReplace(backupPath, targetPath); err != nil {
+		return err
+	}
+	if err := os.Remove(backupPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
 	return nil
 }
 
@@ -369,11 +511,8 @@ func (a *App) forceRestorePluginDLLForProduce() error {
 			} else {
 				restoreErr = errors.Join(restoreErr, fmt.Errorf("读取插件 DLL 备份失败: %w", err))
 			}
-		} else if err := copyFileWithReplace(state.backupPath, state.targetPath); err != nil {
+		} else if err := restorePluginDLLBackup(state.backupPath, state.targetPath); err != nil {
 			restoreErr = errors.Join(restoreErr, fmt.Errorf("恢复目标插件 DLL 失败: %w", err))
-		}
-		if err := os.Remove(state.backupPath); err != nil && !os.IsNotExist(err) {
-			restoreErr = errors.Join(restoreErr, fmt.Errorf("清理插件 DLL 备份失败: %w", err))
 		}
 	} else if strings.TrimSpace(state.targetPath) != "" {
 		if err := os.Remove(state.targetPath); err != nil && !os.IsNotExist(err) {

--- a/internal/app/produce_session_test.go
+++ b/internal/app/produce_session_test.go
@@ -15,6 +15,7 @@ import (
 	"cs2-highlight-tool-v2/internal/config"
 	"cs2-highlight-tool-v2/internal/demo"
 	"cs2-highlight-tool-v2/internal/plugingen"
+	"cs2-highlight-tool-v2/internal/producegame"
 	"cs2-highlight-tool-v2/internal/producemerge"
 	"cs2-highlight-tool-v2/internal/producews"
 
@@ -199,6 +200,47 @@ func TestPrepareGameInfoForProduce_RecoversStaleBackupBeforeReinjecting(t *testi
 	}
 }
 
+func TestPrepareGameInfoForProduce_StaleRecoveryPreservesExternalChanges(t *testing.T) {
+	env := setupProducePluginTestEnvironment(t)
+	firstApp := &App{exeDir: env.exeDir}
+	if err := firstApp.prepareGameInfoForProduce(); err != nil {
+		t.Fatalf("first prepare gameinfo: %v", err)
+	}
+
+	current, err := os.ReadFile(env.gameInfoPath)
+	if err != nil {
+		t.Fatalf("read injected gameinfo: %v", err)
+	}
+	externalLine := "\t\tGame\tcustom_external_mount\n"
+	if err := os.WriteFile(env.gameInfoPath, append(current, []byte(externalLine)...), 0644); err != nil {
+		t.Fatalf("write externally changed gameinfo: %v", err)
+	}
+
+	secondApp := &App{exeDir: env.exeDir}
+	if err := secondApp.prepareGameInfoForProduce(); err != nil {
+		t.Fatalf("second prepare gameinfo: %v", err)
+	}
+	if err := secondApp.forceRestoreGameInfoForProduce(); err != nil {
+		t.Fatalf("restore after external gameinfo change: %v", err)
+	}
+	restored, err := os.ReadFile(env.gameInfoPath)
+	if err != nil {
+		t.Fatalf("read restored gameinfo: %v", err)
+	}
+	withoutInjected := string(current)
+	for _, searchPath := range knownInjectedSearchPaths() {
+		var changed bool
+		withoutInjected, changed = producegame.RemoveSearchPath(withoutInjected, searchPath)
+		if !changed {
+			t.Fatalf("test setup should contain the injected %q path", searchPath)
+		}
+	}
+	want := withoutInjected + externalLine
+	if string(restored) != want {
+		t.Fatalf("external gameinfo change was lost:\n got:\n%s\nwant:\n%s", restored, want)
+	}
+}
+
 func TestPrepareAndRestorePluginDLLForProduce_NewTarget(t *testing.T) {
 	env := setupProducePluginTestEnvironment(t)
 	app := &App{exeDir: env.exeDir}
@@ -270,6 +312,68 @@ func TestPrepareAndRestorePluginDLLForProduce_BackupExistingTarget(t *testing.T)
 	}
 	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
 		t.Fatalf("backup path should be removed after restore, stat err=%v", err)
+	}
+}
+
+func TestPreparePluginDLLForProduce_RecoversStaleBackupAcrossAppInstances(t *testing.T) {
+	env := setupProducePluginTestEnvironment(t)
+	if err := os.MkdirAll(env.binDirPath, 0755); err != nil {
+		t.Fatalf("mkdir plugin bin dir: %v", err)
+	}
+	if err := os.WriteFile(env.targetDLLPath, []byte("plugin-old"), 0644); err != nil {
+		t.Fatalf("write existing target dll: %v", err)
+	}
+
+	firstApp := &App{exeDir: env.exeDir}
+	if err := firstApp.preparePluginDLLForProduce(); err != nil {
+		t.Fatalf("first preparePluginDLLForProduce: %v", err)
+	}
+	secondApp := &App{exeDir: env.exeDir}
+	if err := secondApp.preparePluginDLLForProduce(); err != nil {
+		t.Fatalf("second preparePluginDLLForProduce: %v", err)
+	}
+	if err := secondApp.forceRestorePluginDLLForProduce(); err != nil {
+		t.Fatalf("restore after stale plugin backup: %v", err)
+	}
+	restored, err := os.ReadFile(env.targetDLLPath)
+	if err != nil {
+		t.Fatalf("read restored target dll: %v", err)
+	}
+	if string(restored) != "plugin-old" {
+		t.Fatalf("stale backup recovery lost original target, got %q", restored)
+	}
+	if _, err := os.Stat(env.targetDLLPath + producePluginDLLBackupSuffix); !os.IsNotExist(err) {
+		t.Fatalf("stale backup should be removed, stat err=%v", err)
+	}
+}
+
+func TestPreparePluginDLLForProduce_RecoversMissingTargetMarkerAcrossAppInstances(t *testing.T) {
+	env := setupProducePluginTestEnvironment(t)
+	firstApp := &App{exeDir: env.exeDir}
+	if err := firstApp.preparePluginDLLForProduce(); err != nil {
+		t.Fatalf("first preparePluginDLLForProduce: %v", err)
+	}
+	backupPath := env.targetDLLPath + producePluginDLLBackupSuffix
+	marker, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("read missing-target marker: %v", err)
+	}
+	if string(marker) != producePluginDLLMissingMarker {
+		t.Fatalf("unexpected missing-target marker: %q", marker)
+	}
+
+	secondApp := &App{exeDir: env.exeDir}
+	if err := secondApp.preparePluginDLLForProduce(); err != nil {
+		t.Fatalf("second preparePluginDLLForProduce: %v", err)
+	}
+	if err := secondApp.forceRestorePluginDLLForProduce(); err != nil {
+		t.Fatalf("restore after missing-target marker recovery: %v", err)
+	}
+	if _, err := os.Stat(env.targetDLLPath); !os.IsNotExist(err) {
+		t.Fatalf("target dll should be removed after restoring missing target, stat err=%v", err)
+	}
+	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
+		t.Fatalf("missing-target marker should be removed, stat err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve and recover produce-time files/configuration safely
- propagate the configured recording quality through clip generation
- add regression coverage for recovery and record-quality behavior

## Why

The current branch contains the pending critical-review fixes from commit `378d131`. The follow-up 4:3 aspect-ratio/black-border repair will be implemented only after this PR is merged and the local `main` branch is synchronized.

## Validation

- `go test ./internal/app ./internal/clipsjson ./internal/producemerge` ✅
- `cd frontend && npm run build` ✅
- `git diff --check` ✅
- `go test ./...` ⚠️ existing `internal/envsetup/TestRunStartupChecks_CS2ReadyWhenAutoDetectAvailable` cleanup race: TempDir cleanup reports a non-empty directory after asynchronous startup work; the same failure reproduces when the test is run alone.

## Scope

No HLAE/FFmpeg aspect-ratio changes are included in this PR.
