### PR TITLE
fix: preserve aspect ratio in edit transitions

### DIFF
--- a/internal/app/app_edit.go
+++ b/internal/app/app_edit.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,10 +29,12 @@ type EditConcatRequest struct {
 }
 
 type resolvedEditClip struct {
-	VideoPath string
-	Duration  float64
-	Width     int
-	Height    int
+	VideoPath          string
+	Duration           float64
+	Width              int
+	Height             int
+	SampleAspectRatio  string
+	DisplayAspectRatio string
 }
 
 type editEncodeSettings struct {
@@ -126,6 +129,8 @@ func (a *App) resolveEditClips(input []EditConcatClip, forceProbe ...bool) ([]re
 		duration := clip.Duration
 		width := 0
 		height := 0
+		sampleAspectRatio := ""
+		displayAspectRatio := ""
 		if probeForTransitions {
 			info, err := probeVideoStreamInfo(ffprobeExe, p)
 			if err != nil {
@@ -134,6 +139,8 @@ func (a *App) resolveEditClips(input []EditConcatClip, forceProbe ...bool) ([]re
 			duration = info.Duration
 			width = info.Width
 			height = info.Height
+			sampleAspectRatio = info.SampleAspectRatio
+			displayAspectRatio = info.DisplayAspectRatio
 		} else if duration <= 0 {
 			if ffprobeExe == "" {
 				return nil, fmt.Errorf("clip %d duration is invalid and ffprobe not found", i+1)
@@ -156,10 +163,12 @@ func (a *App) resolveEditClips(input []EditConcatClip, forceProbe ...bool) ([]re
 			resolvedDuration = math.Round(duration*1000) / 1000
 		}
 		resolved = append(resolved, resolvedEditClip{
-			VideoPath: p,
-			Duration:  resolvedDuration,
-			Width:     width,
-			Height:    height,
+			VideoPath:          p,
+			Duration:           resolvedDuration,
+			Width:              width,
+			Height:             height,
+			SampleAspectRatio:  sampleAspectRatio,
+			DisplayAspectRatio: displayAspectRatio,
 		})
 	}
 	return resolved, nil
@@ -402,15 +411,17 @@ func buildTransitionFilterGraph(
 
 	width := clips[0].Width
 	height := clips[0].Height
+	targetSampleAspectRatio := editClipSampleAspectRatio(clips[0])
 	filters := make([]string, 0, len(clips)*2+len(clips)-1)
 	for i, duration := range durations {
 		filters = append(filters, fmt.Sprintf(
-			"[%d:v]scale=%d:%d:force_original_aspect_ratio=decrease,pad=%d:%d:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=%d,settb=AVTB,setpts=PTS-STARTPTS,format=yuv420p,trim=duration=%.6f,setpts=PTS-STARTPTS[v%d]",
+			"[%d:v]scale=%d:%d:force_original_aspect_ratio=decrease,pad=%d:%d:(ow-iw)/2:(oh-ih)/2,setsar=%s,fps=%d,settb=AVTB,setpts=PTS-STARTPTS,format=yuv420p,trim=duration=%.6f,setpts=PTS-STARTPTS[v%d]",
 			i,
 			width,
 			height,
 			width,
 			height,
+			targetSampleAspectRatio,
 			fps,
 			duration,
 			i,
@@ -480,6 +491,80 @@ func buildTransitionFilterGraph(
 		Filter:        strings.Join(filters, ";"),
 		TotalDuration: currentDuration,
 	}, nil
+}
+
+func editClipSampleAspectRatio(clip resolvedEditClip) string {
+	if ratio, ok := parseEditAspectRatio(clip.SampleAspectRatio); ok {
+		return ratio.String()
+	}
+
+	displayRatio, ok := parseEditAspectRatio(clip.DisplayAspectRatio)
+	if !ok || clip.Width <= 0 || clip.Height <= 0 {
+		return "1/1"
+	}
+
+	return reduceEditAspectRatio(
+		displayRatio.num*int64(clip.Height),
+		displayRatio.den*int64(clip.Width),
+	)
+}
+
+type editAspectRatio struct {
+	num int64
+	den int64
+}
+
+func (ratio editAspectRatio) String() string {
+	return fmt.Sprintf("%d/%d", ratio.num, ratio.den)
+}
+
+func parseEditAspectRatio(raw string) (editAspectRatio, bool) {
+	ratio := strings.TrimSpace(raw)
+	if ratio == "" || strings.EqualFold(ratio, "N/A") {
+		return editAspectRatio{}, false
+	}
+
+	separator := ":"
+	if !strings.Contains(ratio, separator) {
+		separator = "/"
+	}
+	parts := strings.Split(ratio, separator)
+	if len(parts) != 2 {
+		return editAspectRatio{}, false
+	}
+	numerator, err := strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
+	if err != nil || numerator <= 0 {
+		return editAspectRatio{}, false
+	}
+	denominator, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+	if err != nil || denominator <= 0 {
+		return editAspectRatio{}, false
+	}
+
+	return reduceEditAspectRatioParts(numerator, denominator), true
+}
+
+func reduceEditAspectRatio(numerator, denominator int64) string {
+	if numerator <= 0 || denominator <= 0 {
+		return "1/1"
+	}
+	reduced := reduceEditAspectRatioParts(numerator, denominator)
+	return reduced.String()
+}
+
+func reduceEditAspectRatioParts(numerator, denominator int64) editAspectRatio {
+	common := editAspectRatioGCD(numerator, denominator)
+	return editAspectRatio{num: numerator / common, den: denominator / common}
+}
+
+func editAspectRatioGCD(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
 }
 
 func alignToFrameGrid(seconds float64, fps int) float64 {

--- a/internal/app/app_edit_test.go
+++ b/internal/app/app_edit_test.go
@@ -78,6 +78,24 @@ func TestBuildTransitionFilterGraph_FadeUsesAlignedOffsetAndResolution(t *testin
 	}
 }
 
+func TestBuildTransitionFilterGraph_PreservesTargetSampleAspectRatio(t *testing.T) {
+	plan, err := buildTransitionFilterGraph([]resolvedEditClip{
+		{Duration: 3, Width: 1440, Height: 1080, SampleAspectRatio: "4:3", DisplayAspectRatio: "16:9"},
+		{Duration: 2, Width: 1280, Height: 960, SampleAspectRatio: "1:1", DisplayAspectRatio: "4:3"},
+	}, map[int]EditConcatTransition{
+		0: {Type: "fade", Duration: 0.5},
+	}, 60)
+	if err != nil {
+		t.Fatalf("buildTransitionFilterGraph: %v", err)
+	}
+	if strings.Count(plan.Filter, "setsar=4/3") != 2 {
+		t.Fatalf("every input should use the first clip SAR, got: %s", plan.Filter)
+	}
+	if strings.Contains(plan.Filter, "setsar=1,") || strings.Contains(plan.Filter, "setsar=1/1,") {
+		t.Fatalf("transition graph must not force square pixels for stretched 4:3 clips, got: %s", plan.Filter)
+	}
+}
+
 func TestBuildTransitionFilterGraph_MixesFadeAndHardCut(t *testing.T) {
 	plan, err := buildTransitionFilterGraph([]resolvedEditClip{
 		{Duration: 3, Width: 1920, Height: 1080},
@@ -177,8 +195,8 @@ func TestProbeVideoStreamInfo_StreamDurationPriorityAndFormatFallback(t *testing
 	}{
 		{
 			name:    "stream duration has priority",
-			payload: `{"streams":[{"duration":"2.345","width":1920,"height":1080}],"format":{"duration":"9.000"}}`,
-			want:    probedVideoInfo{Duration: 2.345, Width: 1920, Height: 1080},
+			payload: `{"streams":[{"duration":"2.345","width":1440,"height":1080,"sample_aspect_ratio":"4:3","display_aspect_ratio":"16:9"}],"format":{"duration":"9.000"}}`,
+			want:    probedVideoInfo{Duration: 2.345, Width: 1440, Height: 1080, SampleAspectRatio: "4:3", DisplayAspectRatio: "16:9"},
 		},
 		{
 			name:    "format duration fallback",
@@ -234,7 +252,7 @@ func TestResolveEditClips_TransitionPathAlwaysProbes(t *testing.T) {
 	old := ffmpegCommand
 	ffmpegCommand = fakeFFProbeCommandJSON
 	t.Cleanup(func() { ffmpegCommand = old })
-	t.Setenv("EDIT_FFPROBE_JSON", `{"streams":[{"duration":"4.250","width":1600,"height":900}],"format":{"duration":"8.000"}}`)
+	t.Setenv("EDIT_FFPROBE_JSON", `{"streams":[{"duration":"4.250","width":1600,"height":900,"sample_aspect_ratio":"1:1","display_aspect_ratio":"16:9"}],"format":{"duration":"8.000"}}`)
 
 	app := &App{exeDir: exeDir}
 	got, err := app.resolveEditClips([]EditConcatClip{{VideoPath: clipPath, Duration: 99}}, true)
@@ -244,8 +262,40 @@ func TestResolveEditClips_TransitionPathAlwaysProbes(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("resolved clips=%d want 1", len(got))
 	}
-	if got[0].Duration != 4.25 || got[0].Width != 1600 || got[0].Height != 900 {
+	if got[0].Duration != 4.25 || got[0].Width != 1600 || got[0].Height != 900 || got[0].SampleAspectRatio != "1:1" || got[0].DisplayAspectRatio != "16:9" {
 		t.Fatalf("resolved clip=%+v; probe result should override request duration", got[0])
+	}
+}
+
+func TestEditClipSampleAspectRatio(t *testing.T) {
+	tests := []struct {
+		name string
+		clip resolvedEditClip
+		want string
+	}{
+		{
+			name: "sample aspect ratio takes precedence",
+			clip: resolvedEditClip{Width: 1440, Height: 1080, SampleAspectRatio: "4:3", DisplayAspectRatio: "4:3"},
+			want: "4/3",
+		},
+		{
+			name: "display aspect ratio derives sample aspect ratio",
+			clip: resolvedEditClip{Width: 1440, Height: 1080, DisplayAspectRatio: "16:9"},
+			want: "4/3",
+		},
+		{
+			name: "invalid metadata falls back to square pixels",
+			clip: resolvedEditClip{Width: 1440, Height: 1080, SampleAspectRatio: "N/A", DisplayAspectRatio: "N/A"},
+			want: "1/1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := editClipSampleAspectRatio(tt.clip); got != tt.want {
+				t.Fatalf("editClipSampleAspectRatio()=%q want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/app/edit_ffmpeg.go
+++ b/internal/app/edit_ffmpeg.go
@@ -22,9 +22,11 @@ var ffmpegCommand = exec.Command
 var ffmpegCommandContext = exec.CommandContext
 
 type probedVideoInfo struct {
-	Duration float64
-	Width    int
-	Height   int
+	Duration           float64
+	Width              int
+	Height             int
+	SampleAspectRatio  string
+	DisplayAspectRatio string
 }
 
 func (a *App) ProbeClipDuration(videoPath string) (float64, error) {
@@ -79,7 +81,7 @@ func probeVideoStreamInfo(ffprobeExe, videoPath string) (probedVideoInfo, error)
 		ffprobeExe,
 		"-v", "error",
 		"-select_streams", "v:0",
-		"-show_entries", "stream=duration,width,height",
+		"-show_entries", "stream=duration,width,height,sample_aspect_ratio,display_aspect_ratio",
 		"-show_entries", "format=duration",
 		"-of", "json",
 		videoPath,
@@ -93,9 +95,11 @@ func probeVideoStreamInfo(ffprobeExe, videoPath string) (probedVideoInfo, error)
 
 	var payload struct {
 		Streams []struct {
-			Duration json.RawMessage `json:"duration"`
-			Width    int             `json:"width"`
-			Height   int             `json:"height"`
+			Duration           json.RawMessage `json:"duration"`
+			Width              int             `json:"width"`
+			Height             int             `json:"height"`
+			SampleAspectRatio  string          `json:"sample_aspect_ratio"`
+			DisplayAspectRatio string          `json:"display_aspect_ratio"`
 		} `json:"streams"`
 		Format struct {
 			Duration json.RawMessage `json:"duration"`
@@ -121,9 +125,11 @@ func probeVideoStreamInfo(ffprobeExe, videoPath string) (probedVideoInfo, error)
 	}
 
 	return probedVideoInfo{
-		Duration: duration,
-		Width:    stream.Width,
-		Height:   stream.Height,
+		Duration:           duration,
+		Width:              stream.Width,
+		Height:             stream.Height,
+		SampleAspectRatio:  strings.TrimSpace(stream.SampleAspectRatio),
+		DisplayAspectRatio: strings.TrimSpace(stream.DisplayAspectRatio),
 	}, nil
 }
 


### PR DESCRIPTION
## What changed

Preserve source video sample/display aspect-ratio metadata when composing edit timelines with transitions.

## Why

4:3 stretched recordings are encoded at 1440x1080 or 1280x960 and marked for 16:9 playback. The transition filter previously forced `setsar=1`, which discarded the stretch metadata and could produce incorrect 4:3 playback or apparent side borders after editing.

## Implementation

- Read `sample_aspect_ratio` and `display_aspect_ratio` from ffprobe.
- Prefer the first clip's valid SAR in the transition filter graph.
- Derive SAR from DAR and encoded dimensions when needed, with a square-pixel fallback.
- Add regression coverage for metadata parsing and stretched 4:3 transition graphs.

## Validation

- `go vet ./...` passed.
- Changed `internal/app` tests pass.
- Full `go test ./...` was run; an unrelated intermittent `internal/envsetup` TempDir cleanup failure occurred in `TestRunStartupChecks_CS2ReadyWhenAutoDetectAvailable` (directory remained non-empty during asynchronous FFmpeg profile detection).
