### PR TITLE
fix(producews): recover queue after acked mid-demo reconnect with los…

### DIFF
--- a/internal/producews/service.go
+++ b/internal/producews/service.go
@@ -183,6 +183,12 @@ type Service struct {
 	reconnectTimer     *time.Timer
 	reconnectDeadline  time.Time
 	replayTimer        *time.Timer
+	midDemoResumeTimer *time.Timer
+	// midDemoResumeGen identifies which armed mid-demo resume timer a callback
+	// belongs to. time.Timer.Stop cannot cancel a callback that already fired
+	// and is waiting for mu, so stale callbacks must verify their generation
+	// before touching midDemoResumeTimer or dispatching.
+	midDemoResumeGen uint64
 	ackTimeout         time.Duration
 	connectWait        time.Duration
 	demoSwitchDelay    time.Duration
@@ -775,6 +781,7 @@ func (s *Service) Stop() error {
 		s.stopAckTimerLocked()
 		s.stopReconnectTimerLocked()
 		s.stopReplayTimerLocked()
+		s.stopMidDemoResumeTimerLocked()
 		s.mu.Unlock()
 		if heartbeatCancel != nil {
 			heartbeatCancel()
@@ -800,6 +807,7 @@ func (s *Service) Stop() error {
 	s.stopAckTimerLocked()
 	s.stopReconnectTimerLocked()
 	s.stopReplayTimerLocked()
+	s.stopMidDemoResumeTimerLocked()
 	heartbeatCancel := s.stopHeartbeatLocked(s.heartbeatConnID)
 	s.address = ""
 	s.relistenAddr = ""
@@ -888,6 +896,7 @@ func (s *Service) StartQueue(demoPaths []string) error {
 	s.gracefulExit = gracefulExitState{}
 	s.stopReconnectTimerLocked()
 	s.stopReplayTimerLocked()
+	s.stopMidDemoResumeTimerLocked()
 	s.queueState = QueueState{
 		Running:      true,
 		Total:        len(demos),
@@ -1164,12 +1173,23 @@ func (s *Service) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	})
 	s.stopReconnectTimerLocked()
 	s.stopReplayTimerLocked()
+	s.stopMidDemoResumeTimerLocked()
 	s.startHeartbeatLocked(id, conn)
 	replayPendingAck := s.queueState.Running && s.queueState.PendingAck
 	dispatchAfterReconnect := s.queueState.Running && !s.queueState.PendingAck &&
 		(s.queueState.CurrentIndex < 0 || s.queueState.Completed > s.queueState.CurrentIndex)
+	// A queue whose current playdemo was already acked but whose demo_done may
+	// have been lost during the disconnect sits at Completed == CurrentIndex.
+	// The plugin may still deliver the durable demo_done on the new connection;
+	// arm a bounded fallback that replays the current demo only when it does
+	// not, so the queue can never hang permanently on a lost demo_done.
+	midDemoResume := s.queueState.Running && !s.queueState.PendingAck &&
+		s.queueState.CurrentIndex >= 0 && s.queueState.Completed == s.queueState.CurrentIndex
 	if replayPendingAck {
 		s.startReplayTimerLocked(id, s.queueState.CurrentDemoPath)
+	}
+	if midDemoResume {
+		s.startMidDemoResumeTimerLocked(id, s.queueState.CurrentDemoPath)
 	}
 	s.emitWSStateLocked()
 	s.mu.Unlock()
@@ -1502,6 +1522,7 @@ func (s *Service) handleDemoDone(payload demoEventPayload) {
 	s.queueState.UpdatedAtMs = nowMs()
 	s.stopAckTimerLocked()
 	s.stopReplayTimerLocked()
+	s.stopMidDemoResumeTimerLocked()
 	s.emitQueueStateLocked()
 	s.mu.Unlock()
 	s.recordDiagnostic("info", "queue", "demo_done", "游戏插件已完成 Demo", nil, map[string]string{"demo_path": payload.DemoPath})
@@ -1538,6 +1559,14 @@ func (s *Service) dispatchNextDemo() {
 		s.startReconnectTimerLocked()
 		s.mu.Unlock()
 		s.recordDiagnostic("warning", "queue", "dispatch_waiting_for_connection", "切换 Demo 时游戏插件未连接，等待重连", nil, nil)
+		return
+	}
+	// A playdemo for the next index may already be in flight: the reconnect
+	// dispatch and the demo_done-triggered delayed dispatch can race. When an
+	// ack is already pending, the ack/replay timers own resends for that index,
+	// so dispatching here would double-send playdemo.
+	if s.queueState.PendingAck {
+		s.mu.Unlock()
 		return
 	}
 
@@ -1639,6 +1668,92 @@ func (s *Service) stopReplayTimerLocked() {
 		s.replayTimer.Stop()
 		s.replayTimer = nil
 	}
+}
+
+// startMidDemoResumeTimerLocked arms the bounded fallback for an
+// acked-mid-demo reconnect: the plugin is given one replay window to deliver
+// the durable demo_done for the current demo before the demo is replayed.
+// Caller must hold s.mu.
+func (s *Service) startMidDemoResumeTimerLocked(connID uint64, demoPath string) {
+	s.stopMidDemoResumeTimerLocked()
+	delay := s.replayWindow
+	if delay <= 0 {
+		delay = defaultReplayWindow
+	}
+	s.midDemoResumeGen++
+	gen := s.midDemoResumeGen
+	s.midDemoResumeTimer = time.AfterFunc(delay, func() {
+		s.resumeAckedMidDemo(connID, demoPath, gen)
+	})
+}
+
+// stopMidDemoResumeTimerLocked stops the armed timer and invalidates its
+// generation so an in-flight callback of the previous generation cannot clear
+// a newer timer handle or dispatch. Caller must hold s.mu.
+func (s *Service) stopMidDemoResumeTimerLocked() {
+	if s.midDemoResumeTimer != nil {
+		s.midDemoResumeTimer.Stop()
+		s.midDemoResumeTimer = nil
+	}
+	s.midDemoResumeGen++
+}
+
+// resumeAckedMidDemo is the fallback fired when the plugin did not replay
+// demo_done after an acked-mid-demo reconnect. It replays the current demo so
+// the queue resumes instead of hanging forever. The generation guard ensures a
+// superseded timer callback can neither clobber a newer timer handle nor
+// dispatch, and the dispatch itself is claimed atomically under mu
+// (PendingAck=true) so no interleaving demo_done/reconnect can steal the
+// write between validation and sending.
+func (s *Service) resumeAckedMidDemo(connID uint64, demoPath string, gen uint64) {
+	s.mu.Lock()
+	if s.midDemoResumeGen != gen {
+		s.mu.Unlock()
+		return
+	}
+	s.midDemoResumeTimer = nil
+	if !s.queueState.Running || s.queueState.PendingAck ||
+		s.queueState.Completed != s.queueState.CurrentIndex ||
+		s.queueState.CurrentDemoPath != demoPath ||
+		s.gameConn == nil || s.gameConnID != connID {
+		s.mu.Unlock()
+		return
+	}
+	// Claim the stuck demo atomically: mark the ack pending and snapshot the
+	// write target before releasing mu, mirroring dispatchNextDemo's claim.
+	s.queueState.PendingAck = true
+	s.queueState.UpdatedAtMs = nowMs()
+	conn := s.gameConn
+	index := s.queueState.CurrentIndex
+	path := s.queueState.CurrentDemoPath
+	writeTimeout := s.writeTimeout
+	s.mu.Unlock()
+
+	s.recordDiagnostic("warning", "reconnect", "mid_demo_resume_timeout", "重连后未收到插件回放的 demo_done，重放当前 Demo", nil, map[string]string{
+		"demo_path": demoPath,
+	})
+
+	if err := s.writeOutgoing(conn, outgoingMessage{
+		Name:    "playdemo",
+		Payload: path,
+	}, writeTimeout); err != nil {
+		s.recordDiagnostic("warning", "write", "mid_demo_resume_failed", "重放当前 Demo 失败，等待连接恢复", err, map[string]string{"demo_path": demoPath})
+		// A failed write means this connection is no longer reliable. Closing
+		// it sends the normal read-loop through the single reconnect-grace
+		// path instead of creating a second queue-failure path here.
+		_ = conn.Close()
+		return
+	}
+
+	s.mu.Lock()
+	if s.queueState.Running && s.queueState.PendingAck &&
+		s.queueState.CurrentIndex == index && s.queueState.CurrentDemoPath == path &&
+		s.gameConnID == connID {
+		s.startAckTimerLocked(path)
+		s.emitQueueStateLocked()
+	}
+	s.mu.Unlock()
+	s.recordDiagnostic("info", "reconnect", "mid_demo_resumed", "已重放当前 Demo 恢复制作队列", nil, map[string]string{"demo_path": demoPath})
 }
 
 func (s *Service) resendPendingAckDemo(connID uint64, demoPath string) {
@@ -1789,6 +1904,7 @@ func (s *Service) finishQueueLocked() {
 	s.stopAckTimerLocked()
 	s.stopReconnectTimerLocked()
 	s.stopReplayTimerLocked()
+	s.stopMidDemoResumeTimerLocked()
 	s.queueState.Running = false
 	s.queueState.PendingAck = false
 	s.queueState.CurrentIndex = -1
@@ -1801,6 +1917,7 @@ func (s *Service) failQueueLocked(reason string) {
 	s.stopAckTimerLocked()
 	s.stopReconnectTimerLocked()
 	s.stopReplayTimerLocked()
+	s.stopMidDemoResumeTimerLocked()
 	s.queueState.Running = false
 	s.queueState.PendingAck = false
 	s.queueState.CurrentIndex = -1

--- a/internal/producews/service_test.go
+++ b/internal/producews/service_test.go
@@ -622,6 +622,222 @@ func TestService_ReconnectAfterAckAcceptsDurableDemoDone(t *testing.T) {
 	})
 }
 
+func TestService_ReconnectAfterAckWithoutDemoDoneRecoversQueue(t *testing.T) {
+	svc := New("127.0.0.1:0", nil)
+	svc.SetReconnectGrace(time.Second)
+	svc.SetReplayWindow(25 * time.Millisecond)
+	svc.SetDemoSwitchDelay(25 * time.Millisecond)
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	firstConn := mustConnectGameClient(t, svc.Address())
+	if err := svc.StartQueue([]string{"a.dem", "b.dem"}); err != nil {
+		t.Fatalf("StartQueue: %v", err)
+	}
+	first := mustReadWSMessage(t, firstConn)
+	if got := mustStringPayload(t, first.Payload); first.Name != "playdemo" || got != "a.dem" {
+		t.Fatalf("initial message = %+v, want playdemo a.dem", first)
+	}
+	mustWriteJSON(t, firstConn, map[string]any{"name": "status", "payload": "ok"})
+	waitFor(t, time.Second, func() bool {
+		state := svc.GetQueueState()
+		return state.Running && !state.PendingAck && state.CurrentIndex == 0
+	})
+
+	// The plugin finishes a.dem while disconnected: its demo_done is lost with
+	// the dead connection. After reconnecting within the grace window the
+	// queue must not hang — once the resume window expires without a replayed
+	// demo_done, the service falls back to replaying the current demo.
+	_ = firstConn.Close()
+
+	secondConn := mustConnectGameClient(t, svc.Address())
+	defer secondConn.Close()
+	replayed := mustReadWSMessage(t, secondConn)
+	if got := mustStringPayload(t, replayed.Payload); replayed.Name != "playdemo" || got != "a.dem" {
+		t.Fatalf("recovery message = %+v, want replayed playdemo a.dem", replayed)
+	}
+	mustWriteJSON(t, secondConn, map[string]any{"name": "status", "payload": "ok"})
+	waitFor(t, time.Second, func() bool {
+		state := svc.GetQueueState()
+		return state.Running && !state.PendingAck
+	})
+	mustWriteJSON(t, secondConn, map[string]any{
+		"name": "demo_done",
+		"payload": map[string]any{
+			"demo_path": "a.dem",
+			"reason":    "disconnect",
+			"ts_ms":     time.Now().UnixMilli(),
+		},
+	})
+
+	next := mustReadWSMessage(t, secondConn)
+	if got := mustStringPayload(t, next.Payload); next.Name != "playdemo" || got != "b.dem" {
+		t.Fatalf("next message = %+v, want playdemo b.dem", next)
+	}
+	mustWriteJSON(t, secondConn, map[string]any{"name": "status", "payload": "ok"})
+	mustWriteJSON(t, secondConn, map[string]any{
+		"name": "demo_done",
+		"payload": map[string]any{
+			"demo_path": "b.dem",
+			"reason":    "disconnect",
+			"ts_ms":     time.Now().UnixMilli(),
+		},
+	})
+	waitFor(t, 2*time.Second, func() bool {
+		state := svc.GetQueueState()
+		return !state.Running && state.Completed == 2 && state.LastError == ""
+	})
+}
+
+func TestService_DispatchNextDemoSkipsWhenAckAlreadyPending(t *testing.T) {
+	svc := New("127.0.0.1:0", nil)
+	svc.started = true
+	svc.gameConn = &websocket.Conn{}
+	svc.gameConnID = 1
+	svc.queueState = QueueState{
+		Running:      true,
+		Total:        1,
+		Completed:    0,
+		CurrentIndex: 0,
+		PendingAck:   true,
+		Demos:        []string{"demo.dem"},
+	}
+	writeCalled := false
+	svc.writeJSONFn = func(_ *websocket.Conn, _ outgoingMessage, _ time.Duration) error {
+		writeCalled = true
+		return nil
+	}
+
+	svc.dispatchNextDemo()
+
+	svc.mu.Lock()
+	pending := svc.queueState.PendingAck
+	svc.mu.Unlock()
+	if writeCalled {
+		t.Fatal("dispatchNextDemo wrote playdemo while an ack was already pending")
+	}
+	if !pending {
+		t.Fatal("pending ack state should be preserved")
+	}
+}
+
+func TestService_ReconnectAfterAckDoesNotReplayWhenDemoDoneArrives(t *testing.T) {
+	svc := New("127.0.0.1:0", nil)
+	svc.SetReconnectGrace(time.Second)
+	// A long resume window guarantees the durable demo_done (sent immediately
+	// after the reconnect) always lands first, even on a loaded CI machine;
+	// the assertion is that it stops the fallback replay.
+	svc.SetReplayWindow(2 * time.Second)
+	svc.SetDemoSwitchDelay(25 * time.Millisecond)
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	firstConn := mustConnectGameClient(t, svc.Address())
+	if err := svc.StartQueue([]string{"a.dem", "b.dem"}); err != nil {
+		t.Fatalf("StartQueue: %v", err)
+	}
+	first := mustReadWSMessage(t, firstConn)
+	if got := mustStringPayload(t, first.Payload); first.Name != "playdemo" || got != "a.dem" {
+		t.Fatalf("initial message = %+v, want playdemo a.dem", first)
+	}
+	mustWriteJSON(t, firstConn, map[string]any{"name": "status", "payload": "ok"})
+	waitFor(t, time.Second, func() bool {
+		state := svc.GetQueueState()
+		return state.Running && !state.PendingAck
+	})
+	_ = firstConn.Close()
+
+	secondConn := mustConnectGameClient(t, svc.Address())
+	defer secondConn.Close()
+	mustWriteJSON(t, secondConn, map[string]any{
+		"name": "demo_done",
+		"payload": map[string]any{
+			"demo_path": "a.dem",
+			"reason":    "plugin_replay",
+			"ts_ms":     time.Now().UnixMilli(),
+		},
+	})
+
+	// The durable demo_done arrived inside the resume window: the queue must
+	// advance straight to the next demo without replaying a.dem.
+	next := mustReadWSMessage(t, secondConn)
+	if got := mustStringPayload(t, next.Payload); next.Name != "playdemo" || got != "b.dem" {
+		t.Fatalf("message after durable demo_done = %+v, want playdemo b.dem", next)
+	}
+	mustWriteJSON(t, secondConn, map[string]any{"name": "status", "payload": "ok"})
+	waitFor(t, time.Second, func() bool {
+		state := svc.GetQueueState()
+		return state.Running && !state.PendingAck && state.CurrentDemoPath == "b.dem"
+	})
+
+	// While the queue is still recording b.dem, give any incorrect replay of
+	// a.dem ample time to surface. Heartbeats are 15s apart, so nothing
+	// legitimate should arrive in this window.
+	_ = secondConn.SetReadDeadline(time.Now().Add(400 * time.Millisecond))
+	var msg wsMessage
+	if err := secondConn.ReadJSON(&msg); err == nil {
+		t.Fatalf("unexpected message while queue continued to next demo: %+v", msg)
+	}
+}
+
+func TestService_MidDemoResumeStaleCallbackDoesNotClearNewTimer(t *testing.T) {
+	svc := New("127.0.0.1:0", nil)
+	svc.started = true
+	svc.gameConn = &websocket.Conn{}
+	svc.gameConnID = 1
+	svc.queueState = QueueState{
+		Running:         true,
+		Total:           1,
+		Completed:       0,
+		CurrentIndex:    0,
+		CurrentDemoPath: "a.dem",
+		PendingAck:      false,
+		Demos:           []string{"a.dem"},
+	}
+	// Use a long window so the real timers never fire during the test.
+	svc.replayWindow = time.Hour
+	writeCalled := false
+	svc.writeJSONFn = func(_ *websocket.Conn, _ outgoingMessage, _ time.Duration) error {
+		writeCalled = true
+		return nil
+	}
+
+	svc.mu.Lock()
+	svc.startMidDemoResumeTimerLocked(1, "a.dem")
+	firstGen := svc.midDemoResumeGen
+	svc.mu.Unlock()
+
+	// A second connection supersedes the first timer.
+	svc.gameConnID = 2
+	svc.mu.Lock()
+	svc.startMidDemoResumeTimerLocked(2, "a.dem")
+	secondGen := svc.midDemoResumeGen
+	secondTimer := svc.midDemoResumeTimer
+	svc.mu.Unlock()
+
+	// The first timer's callback had already fired and was waiting for mu; it
+	// now runs late. It must neither clear the newer timer handle nor write.
+	svc.resumeAckedMidDemo(1, "a.dem", firstGen)
+
+	svc.mu.Lock()
+	timer := svc.midDemoResumeTimer
+	gen := svc.midDemoResumeGen
+	svc.mu.Unlock()
+	if timer != secondTimer {
+		t.Fatal("stale callback cleared the newer timer handle")
+	}
+	if gen != secondGen {
+		t.Fatalf("generation changed by stale callback: got %d, want %d", gen, secondGen)
+	}
+	if writeCalled {
+		t.Fatal("stale callback dispatched a playdemo write")
+	}
+}
+
 func TestService_HeartbeatPongKeepsConnectionAlive(t *testing.T) {
 	svc := New("127.0.0.1:0", nil)
 	svc.heartbeatInterval = 15 * time.Millisecond


### PR DESCRIPTION
…t demo_done

A queue whose current playdemo was already acked but whose demo_done was lost during a disconnect sat at Completed == CurrentIndex with no pending ack to replay and no completed demo to step past, so the queue hung forever: the session worker never observed the queue stop, CS2 was never closed, and every later recording request was rejected until app restart.

- Arm a bounded mid-demo resume timer on reconnect: the plugin gets one replay window to deliver the durable demo_done before the current demo is replayed, matching the existing replay-window design.
- Bind the timer callback to its arming generation so a superseded callback can neither clear a newer timer handle nor dispatch (time.Timer.Stop cannot cancel an in-flight callback).
- Claim the replay dispatch atomically under mu (PendingAck=true) so no interleaving demo_done/reconnect can race the write, and restart the ack timer after a successful resend.
- Guard dispatchNextDemo against dispatching while an ack is already pending to prevent double playdemo sends between the reconnect path and the demo_done-triggered delayed dispatch.

Tests: end-to-end recovery for the lost-demo_done reconnect, no-replay when the durable demo_done arrives inside the window, stale-callback generation guard, and pending-ack dispatch skip.