### PR TITLE
feat(clips): scope advanced filter facets to selected player

### DIFF
--- a/frontend/src/features/clips/pages/ClipsPage.vue
+++ b/frontend/src/features/clips/pages/ClipsPage.vue
@@ -319,7 +319,7 @@
                   :player-options="playerOptions"
                   :player-steam-id="selectedPlayerSteamID"
                   :matched-count="filteredKills.length"
-                  :total-count="allDemoKills.length"
+                  :total-count="scopedKills.length"
                   :addable-count="addableKills.length"
                   :selected-count="getMaterialSelectionCount(activeDemoEntry)"
                   :max-round="maxRound"
@@ -423,11 +423,14 @@ import {
 } from "@/shared/clip-views";
 import {
   ALL_PLAYERS_VALUE,
+  collectScopedKills,
   groupDemoWeapons,
   isKillFilterActive,
   maxKillDistance,
   resolvePresetPatch,
   resolvePrimaryView,
+  sanitizeFilterForScopedKills,
+  type KillFilter,
   type KillFilterPreset,
   type KillPlayerRole,
 } from "@/shared/kill-filter";
@@ -532,6 +535,9 @@ const deathPlayers = computed(() => getDeathPlayers(activeDemoEntry.value));
 const fullRoundPlayers = computed(() => getFullRoundPlayers(activeDemoEntry.value));
 
 const allDemoKills = computed(() => getAllDemoKills(activeDemoEntry.value));
+const scopedKills = computed(() =>
+  collectScopedKills(allDemoKills.value, killFilter.value, selectedPlayerSteamID.value),
+);
 const filteredKills = computed(() =>
   fullRoundPOVEnabled.value ? [] : getFilteredKills(activeDemoEntry.value),
 );
@@ -543,8 +549,8 @@ const addableKills = computed(() =>
 const maxRound = computed(() =>
   Math.max(activeDemoEntry.value?.meta?.total_rounds ?? 0, ...allDemoKills.value.map((k) => k.round), 1),
 );
-const maxDistance = computed(() => Math.max(maxKillDistance(allDemoKills.value), 1));
-const weaponGroups = computed(() => groupDemoWeapons(allDemoKills.value));
+const maxDistance = computed(() => Math.max(maxKillDistance(scopedKills.value), 1));
+const weaponGroups = computed(() => groupDemoWeapons(scopedKills.value));
 
 const playerOptions = computed<SelectOption[]>(() => {
   if (fullRoundPOVEnabled.value) {
@@ -684,6 +690,26 @@ function handleExpandedChange(names: string | number | Array<string | number> | 
   }
 }
 
+function sanitizeFilterConditionsForContext(
+  entry: DemoListEntry | null,
+  overridePlayerSteamID?: string,
+  overrideRole?: KillPlayerRole,
+  overrideIgnorePlayer?: boolean,
+) {
+  if (!entry) return;
+  const filter = getKillFilter(entry);
+  const playerSteamID = overridePlayerSteamID ?? getSelectedPlayerSteamID(entry);
+  const role = overrideRole ?? filter.role;
+  const ignorePlayer = overrideIgnorePlayer ?? filter.ignore_player;
+
+  const tempFilter: KillFilter = { ...filter, role, ignore_player: ignorePlayer };
+  const scoped = collectScopedKills(getAllDemoKills(entry), tempFilter, playerSteamID);
+  const patch = sanitizeFilterForScopedKills(filter, scoped);
+  if (Object.keys(patch).length > 0) {
+    patchKillFilter(entry, patch);
+  }
+}
+
 async function handlePlayerChange(next: string | number | null) {
   if (next == null) {
     return;
@@ -692,6 +718,7 @@ async function handlePlayerChange(next: string | number | null) {
   const entry = activeDemoEntry.value;
   setSelectedPlayerSteamID(entry, playerSteamID);
   syncFullRoundPOVPlayer(entry, playerSteamID);
+  sanitizeFilterConditionsForContext(entry, playerSteamID);
   if (fullRoundPOVEnabled.value && playerSteamID) {
     await fetchFullRoundPOVPlan(entry, playerSteamID);
   }
@@ -725,16 +752,20 @@ function toggleKillSelection(kill: DemoClipKill) {
 
 function handleRoleChange(role: KillPlayerRole) {
   setKillFilterRole(activeDemoEntry.value, role);
+  sanitizeFilterConditionsForContext(activeDemoEntry.value, undefined, role);
 }
 
 function handleIgnorePlayerChange(ignore: boolean) {
   patchKillFilter(activeDemoEntry.value, { ignore_player: ignore });
+  if (!ignore) {
+    sanitizeFilterConditionsForContext(activeDemoEntry.value, undefined, undefined, false);
+  }
 }
 
 function handleApplyPreset(preset: KillFilterPreset) {
   // Presets name weapon families; they only become concrete weapon names once
-  // there is a demo to resolve them against.
-  patchKillFilter(activeDemoEntry.value, resolvePresetPatch(preset, allDemoKills.value));
+  // there is a candidate list to resolve them against.
+  patchKillFilter(activeDemoEntry.value, resolvePresetPatch(preset, scopedKills.value));
 }
 
 function handleSelectAllFiltered() {

--- a/frontend/src/shared/kill-filter.ts
+++ b/frontend/src/shared/kill-filter.ts
@@ -249,6 +249,55 @@ function matchesPlayer(kill: DemoClipKill, filter: KillFilter, playerSteamID: st
   }
 }
 
+/**
+ * All kills in scope for the active player and role, before any facet conditions
+ * (weapons, traits, distance, rounds) are applied.
+ *
+ * This forms the candidate pool for facet summaries: the weapons the player
+ * actually used (or suffered), the maximum distance they recorded, and the
+ * denominator of the match counter.
+ */
+export function collectScopedKills(
+  kills: DemoClipKill[],
+  filter: KillFilter,
+  playerSteamID: string,
+): DemoClipKill[] {
+  if (filter.ignore_player || !playerSteamID) {
+    return kills;
+  }
+  return kills.filter((kill) => matchesPlayer(kill, filter, playerSteamID));
+}
+
+/**
+ * Prunes filter conditions that become impossible or invalid when moving to a
+ * new scoped candidate list (e.g. switching to a player who never used the
+ * currently selected weapons, or whose kills were all shorter than the current
+ * min distance threshold).
+ */
+export function sanitizeFilterForScopedKills(
+  filter: KillFilter,
+  scopedKills: DemoClipKill[],
+): Partial<KillFilter> {
+  const patch: Partial<KillFilter> = {};
+  if (filter.weapons.length > 0) {
+    const availableWeapons = new Set<string>();
+    for (const k of scopedKills) {
+      if (k.weapon_name) availableWeapons.add(k.weapon_name);
+    }
+    const retained = filter.weapons.filter((w) => availableWeapons.has(w));
+    if (retained.length !== filter.weapons.length) {
+      patch.weapons = retained;
+    }
+  }
+  if (filter.distance) {
+    const maxDist = maxKillDistance(scopedKills);
+    if (filter.distance[0] > maxDist) {
+      patch.distance = null;
+    }
+  }
+  return patch;
+}
+
 /** Tests one kill against the filter. An empty group means "no constraint". */
 export function matchKill(kill: DemoClipKill, filter: KillFilter, playerSteamID: string): boolean {
   if (!matchesPlayer(kill, filter, playerSteamID)) return false;


### PR DESCRIPTION
## 变更概述

在前端片段选择页（`ClipsPage.vue`）中，将“更多条件”高级面板的筛选候选集由全局全场击杀（`allDemoKills`）重构为基于当前上下文的动态候选集（`scopedKills`）：

1. **选中【具体玩家】时**：
   - 提取该玩家在当前角色（killer / victim）下的击杀/死亡集合作为基准源；
   - 武器列表仅展示该玩家使用过的武器，角标数字仅统计该玩家的击杀数；
   - 击杀距离滑块最大值（`maxDistance`）取该玩家个人最远击杀距离；
   - 底部计数（`totalCount`）分母显示该玩家总击杀数（如 `匹配 6 / 15 个击杀`）；
   - 预设（Presets）基于该玩家实际用过的武器族进行匹配；
   - 切换玩家/角色/忽略状态时，自动清洗失效武器和超界距离条件，防止幽灵死锁。

2. **选中【全部玩家】时**：
   - 自然回退到全场 Demo 全量击杀展示。

## 验证
- `cd frontend && npm run build` 通过（vue-tsc + vite build 0 错误）
- `go test ./...` 全量后端测试通过