### PR TITLE
fix: export produce diagnostics as UTF-8

### DIFF
--- a/internal/app/produce_logs.go
+++ b/internal/app/produce_logs.go
@@ -10,6 +10,8 @@ import (
 	wruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
+const utf8BOM = "\xEF\xBB\xBF"
+
 // ExportProduceWSLogs writes one sanitized diagnostic artifact for the current
 // produce WebSocket session. In tests and headless development it falls back
 // to the managed logs directory when no Wails context is available.
@@ -39,7 +41,11 @@ func (a *App) ExportProduceWSLogs() (string, error) {
 		}
 		targetPath = selected
 	}
-	if err := os.WriteFile(targetPath, []byte(a.produceW.ExportDiagnostics()), 0o644); err != nil {
+	// Keep the exported support report unambiguously UTF-8 for Windows text
+	// viewers that otherwise fall back to the system ANSI code page when the
+	// report starts with an ASCII-only header.
+	content := []byte(utf8BOM + a.produceW.ExportDiagnostics())
+	if err := os.WriteFile(targetPath, content, 0o644); err != nil {
 		return "", fmt.Errorf("写入制作日志文件失败: %w", err)
 	}
 	return targetPath, nil

--- a/internal/app/produce_logs_test.go
+++ b/internal/app/produce_logs_test.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"cs2-highlight-tool-v2/internal/producews"
 )
@@ -12,7 +14,14 @@ import (
 func TestExportProduceWSLogs_HeadlessWritesManagedLogFile(t *testing.T) {
 	dataDir := t.TempDir()
 	service := producews.NewDefault(nil)
-	service.SetDiagnostics(producews.NewDiagnostics(dataDir))
+	diagnostics := producews.NewDiagnostics(dataDir)
+	diagnostics.Record(producews.DiagnosticEvent{
+		Level:   "error",
+		Stage:   "reconnect",
+		Action:  "grace_expired",
+		Message: "等待游戏插件 WebSocket 重连超时",
+	})
+	service.SetDiagnostics(diagnostics)
 	app := &App{dataDir: dataDir, exeDir: t.TempDir(), produceW: service}
 
 	path, err := app.ExportProduceWSLogs()
@@ -26,7 +35,21 @@ func TestExportProduceWSLogs_HeadlessWritesManagedLogFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read export: %v", err)
 	}
-	if !strings.Contains(string(content), "Produce WebSocket Diagnostics") {
+	if !bytes.HasPrefix(content, []byte{0xEF, 0xBB, 0xBF}) {
+		t.Fatalf("export is missing UTF-8 BOM: % x", content[:min(len(content), 3)])
+	}
+	if !utf8.Valid(content[len(utf8BOM):]) {
+		t.Fatal("export content after BOM is not valid UTF-8")
+	}
+	text := string(content[len(utf8BOM):])
+	if !strings.Contains(text, "Produce WebSocket Diagnostics") || !strings.Contains(text, "等待游戏插件 WebSocket 重连超时") {
 		t.Fatalf("unexpected export content: %s", content)
 	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }


### PR DESCRIPTION
## Summary

- 为制作页面导出的诊断日志添加 UTF-8 BOM，避免 Windows 文本查看器按 ANSI/GBK 解码中文。
- 增加包含中文重连超时错误的导出编码回归测试。

## Validation

- go test ./...
- git diff --check