### PR TITLE
fix(settings): refresh detected encoder after startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ CS2 Demo 导入、片段选择、自动录制与后期拼接的 Windows 桌面�
 | `disable_clouds` | 默认 false；开启仅写入 `mirv_sky clouds draw 0`，与天空开关独立 |
 | `pov_radar_enabled` | 默认 false；开启仅写入 `csdm_radar_pov 1`，与 `pov_hud_enabled` 的 VPK/gameinfo 生命周期独立 |
 
-上述命令开关关闭时不写入对应命令或反向重置命令。FFmpeg 探测缓存字段为 `ffmpeg_detected_preset/ffmpeg_detected_encoders/ffmpeg_detected_at`，供自动选择和编码回退使用。`GetClipActionSettings` / `SaveClipActionSettings` 的语音配置必须与 ClipSettings 语义一致。
+上述命令开关关闭时不写入对应命令或反向重置命令。FFmpeg 探测缓存字段为 `ffmpeg_detected_preset/ffmpeg_detected_encoders/ffmpeg_detected_at`，供自动选择和编码回退使用。`GetClipSettings` / `SaveClipSettings` 响应中的 `effective_video_preset/effective_video_encoder/effective_video_status` 是只读的实际编码结果，不改变持久化的 `video_preset=auto`；前端应在探测完成后展示这些字段。`GetClipActionSettings` / `SaveClipActionSettings` 的语音配置必须与 ClipSettings 语义一致。
 
 - 生成入口为 `GeneratePluginJSON`、`GeneratePluginJSONBatch`、`GeneratePluginJSONBatchAndLaunchHLAE`；批量请求通过 `jobs[]` 承载单 Demo 请求。请求/结果结构见 `internal/app/plugin_generate.go`。
 - 新调用使用 `selected_items[]`；`selected_kills` 仅作兼容。`include_killer` 缺省为 true，`include_victim` 控制被害者录制。

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -37,7 +37,7 @@
 - `src/domains/production/` 先建立事件订阅再读取初始快照，并按 `updated_at_ms` 与来源优先级合并；事件不能被延迟快照回滚。初始化/重试/销毁必须沿用其生命周期 API。
 - `src/domains/settings/` 是跨设置入口共享的草稿与确认状态，保存防抖、`flush` 和 `dispose` 必须等待在途读写；读取失败不得把前端占位默认值写回后端。工作目录切换进入 `workspace_init` 时调用 `resetForWorkspace`，离开该阶段后由 `init` 读取新工作目录；旧 generation 的在途读写不得回写当前状态。
 - `src/domains/edit/` 管理剪辑序列和合成进度；应用生命周期使用 `init`/`dispose` 管理订阅，编辑路由卸载不得销毁共享 domain，保证在途导出跨路由完成；旧 epoch 的导出完成或事件不得污染新实例。对方视角快节奏剪辑由 `fastEdit.ts` 提供无头纯函数，开关默认关闭；只处理带完整录制标记的 victim take，按用户序列中相邻且同 Demo/回合/击杀者分组，缺标记素材保持整段，无法满足裁后时长或过长转场时保持整段/硬切。工作区切换须清理序列、开关和 duration 缓存，导出期间冻结请求并禁用编辑。
-- ClipSettings 的允许值、默认值、命令开关语义遵循根文件“设置与插件计划”；前端不得自行决定编码能力或绕过后端归一化。
+- ClipSettings 的允许值、默认值、命令开关语义遵循根文件“设置与插件计划”；前端不得自行决定编码能力或绕过后端归一化。编码器自动探测完成后展示后端返回的 `effective_video_preset/effective_video_encoder`，但提交时仍保留 `video_preset=auto` 用户策略，不把只读结果写回草稿。
 - 精确 SteamID 使用 `steam_id_text` 或对应字符串字段；不得将 number 形式的 `steam_id` 作为请求值。
 - 主视角/对方视角通过 `primary_view` 映射，复用 `src/shared/clip-views.ts`；死亡模式的主视角是 victim，录制角色仍是 killer/victim。
 - 整局 POV 是 Demo 级独立状态，不伪装成普通击杀片段。请求通过 `full_round_pov.player_steam_id` 传递，普通片段通过 `selected_items[]` 传递；victim-only 项传 `include_killer=false`。

--- a/frontend/src/app/AppShell.vue
+++ b/frontend/src/app/AppShell.vue
@@ -31,6 +31,7 @@ import TopBar from "@/app/components/TopBar.vue";
 import StartupWizard from "@/features/startup/components/StartupWizard.vue";
 import WorkspaceInitModal from "@/features/workspace-init/components/WorkspaceInitModal.vue";
 import ChangelogModal from "@/features/changelog/components/ChangelogModal.vue";
+import { shouldRefreshSettingsForStartupState } from "@/app/startup-state";
 import { useChangelog } from "@/features/changelog/composables/useChangelog";
 import { useI18n } from "@/shared/i18n";
 import { backend } from "@/shared/backend";
@@ -142,8 +143,13 @@ function statusForProgressKey(key: string): string {
 
 function applyState(next: StartupState) {
   const previousMode = state.mode;
+  const previousConfig = { ...state.config };
   const wasRunning = state.running;
   Object.assign(state, next);
+
+  if (shouldRefreshSettingsForStartupState(previousMode, previousConfig, next, settingsStore.loaded.value)) {
+    void settingsStore.refresh();
+  }
 
   if (next.mode === "workspace_init" && previousMode !== "workspace_init") {
     settingsStore.resetForWorkspace();

--- a/frontend/src/app/startup-state.ts
+++ b/frontend/src/app/startup-state.ts
@@ -1,0 +1,36 @@
+import type { StartupState } from "../shared/types/startup.js";
+
+function configValue(config: Record<string, unknown>, key: string): string {
+  const value = config[key];
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string").join(",");
+  }
+  return "";
+}
+
+/**
+ * Settings can be loaded while the startup wizard is still running. Refresh
+ * them when the FFmpeg detection cache changes in any startup mode, and once
+ * more when the app enters main so a missed startup event cannot leave stale
+ * capability metadata in an already-loaded settings store.
+ */
+export function shouldRefreshSettingsForStartupState(
+  previousMode: string,
+  previousConfig: Record<string, unknown>,
+  next: Pick<StartupState, "mode" | "config">,
+  settingsLoaded: boolean,
+): boolean {
+  if (!settingsLoaded || next.mode === "workspace_init") {
+    return false;
+  }
+
+  const detectionChanged =
+    configValue(previousConfig, "ffmpeg_detected_preset") !== configValue(next.config, "ffmpeg_detected_preset") ||
+    configValue(previousConfig, "ffmpeg_detected_encoders") !== configValue(next.config, "ffmpeg_detected_encoders") ||
+    configValue(previousConfig, "ffmpeg_detected_at") !== configValue(next.config, "ffmpeg_detected_at");
+
+  return detectionChanged || (previousMode !== "main" && next.mode === "main");
+}

--- a/frontend/src/domains/settings/settings-state.ts
+++ b/frontend/src/domains/settings/settings-state.ts
@@ -42,6 +42,8 @@ export interface SettingsStore {
   /** Identifies the active workspace lifetime. */
   workspaceGeneration: Ref<number>;
   init(): Promise<void>;
+  /** Reload backend-normalized settings without discarding a newer draft. */
+  refresh(): Promise<void>;
   /** Detach all work from the previous workspace and restore the placeholder draft. */
   resetForWorkspace(): void;
   flush(): Promise<void>;
@@ -213,8 +215,8 @@ export function createSettingsStore(options: SettingsStateOptions = {}): Setting
     assignDraft(mergeDraftChanges(backendSettings, loadDraftSnapshot, currentDraft));
   }
 
-  async function fetchSettings(generation: number): Promise<void> {
-    const loadDraftSnapshot = cloneSettings(draftSettings);
+  async function fetchSettings(generation: number, draftSnapshot?: ClipSettings): Promise<void> {
+    const loadDraftSnapshot = cloneSettings(draftSnapshot ?? draftSettings);
     const loadRequestId = ++requestVersion.value;
     latestLoadRequestVersion = loadRequestId;
     loading.value = true;
@@ -260,6 +262,42 @@ export function createSettingsStore(options: SettingsStateOptions = {}): Setting
     }
     const generation = workspaceGeneration.value;
     const task = fetchSettings(generation);
+    activeLoad = task;
+    try {
+      await task;
+    } finally {
+      if (activeLoad === task) {
+        activeLoad = null;
+      }
+    }
+  }
+
+  async function refresh(): Promise<void> {
+    const generation = workspaceGeneration.value;
+
+    // Do not race a settings write with a capability-refresh read. Waiting for
+    // all queued saves keeps the backend response authoritative while the
+    // existing merge logic preserves edits made after each save snapshot.
+    while (activeSave) {
+      await activeSave;
+      if (generation !== workspaceGeneration.value) {
+        return;
+      }
+    }
+    if (activeLoad) {
+      await activeLoad;
+      if (generation !== workspaceGeneration.value) {
+        return;
+      }
+    }
+    if (!loaded.value || generation !== workspaceGeneration.value) {
+      return;
+    }
+
+    const refreshSnapshot = confirmedSettings.value
+      ? cloneSettings(confirmedSettings.value)
+      : cloneSettings(draftSettings);
+    const task = fetchSettings(generation, refreshSnapshot);
     activeLoad = task;
     try {
       await task;
@@ -419,6 +457,7 @@ export function createSettingsStore(options: SettingsStateOptions = {}): Setting
     lastSavedVersion,
     workspaceGeneration,
     init,
+    refresh,
     resetForWorkspace,
     flush,
     dispose,

--- a/frontend/src/features/settings/components/SettingsPanel.vue
+++ b/frontend/src/features/settings/components/SettingsPanel.vue
@@ -295,8 +295,22 @@ const {
 const errorMessage = computed(
   () => settingsStore.errorMessage.value || storage.errorMessage.value || debug.errorMessage.value || localErrorMessage.value,
 );
+
+function effectivePresetLabel(): string {
+  if (settings.effective_video_status !== "ready") {
+    return t("main.settings.video_preset_auto");
+  }
+
+  const preset = (settings.effective_video_preset || "").trim().replace(/_h264$/i, "");
+  const encoder = (settings.effective_video_encoder || "").trim();
+  if (preset && encoder) {
+    return `${preset} (${encoder})`;
+  }
+  return encoder || preset || t("main.settings.video_preset_auto");
+}
+
 const presetOptions = computed(() => [
-  { label: t("main.settings.video_preset_auto"), value: "auto" },
+  { label: effectivePresetLabel(), value: "auto" },
   { label: t("main.settings.video_preset_c1"), value: "c1" },
   { label: t("main.settings.video_preset_n1"), value: "n1" },
   { label: t("main.settings.video_preset_a1"), value: "a1" },

--- a/frontend/src/shared/types/clips.ts
+++ b/frontend/src/shared/types/clips.ts
@@ -10,6 +10,10 @@ export interface ClipSettings {
   edit_fps: number;
   edit_quality: "standard" | "high" | "ultra";
   video_preset: "auto" | "c1" | "n1" | "a1" | "i1";
+  /** Backend-resolved metadata; these do not change the persisted request. */
+  effective_video_preset?: string;
+  effective_video_encoder?: string;
+  effective_video_status?: "manual" | "ready" | "pending" | string;
   launch_resolution: "16:9" | "4:3" | "4:3_1280x960";
   record_output_dir: string;
   enable_spec_show_xray_zero: boolean;

--- a/frontend/tests/settings-state.test.mjs
+++ b/frontend/tests/settings-state.test.mjs
@@ -380,3 +380,47 @@ test("a failed save keeps the draft and a later flush can retry it", async () =>
   assert.equal(store.dirty.value, false);
   await store.dispose();
 });
+
+test("refresh updates the effective encoder while preserving the auto choice and unsaved draft", async () => {
+  let current = settings({
+    video_preset: "auto",
+    effective_video_preset: "c1",
+    effective_video_encoder: "libx264",
+    effective_video_status: "pending",
+  });
+  const calls = [];
+  const store = createSettingsStore({
+    backend: {
+      GetWorkspaceState: async () => workspace(),
+      GetClipSettings: async () => ({ ...current }),
+      SaveClipSettings: async (next) => {
+        calls.push({ ...next });
+        current = { ...current, ...next };
+        return { ...current };
+      },
+    },
+    autoSaveDelayMs: 10,
+  });
+
+  await store.init();
+  store.draftSettings.edit_fps = 120;
+  current = {
+    ...current,
+    effective_video_preset: "n1",
+    effective_video_encoder: "hevc_nvenc",
+    effective_video_status: "ready",
+  };
+
+  await store.refresh();
+
+  assert.equal(store.draftSettings.video_preset, "auto");
+  assert.equal(store.draftSettings.effective_video_preset, "n1");
+  assert.equal(store.draftSettings.effective_video_encoder, "hevc_nvenc");
+  assert.equal(store.draftSettings.edit_fps, 120);
+  assert.equal(store.dirty.value, true);
+
+  await store.flush();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].video_preset, "auto");
+  await store.dispose();
+});

--- a/frontend/tests/settings-state.types.ts
+++ b/frontend/tests/settings-state.types.ts
@@ -17,6 +17,6 @@ const requestSettings: ClipSettings | null = store.requestSnapshot.value?.settin
 void confirmed;
 void requestSettings;
 void store.init();
+void store.refresh();
 void store.flush();
 void store.dispose();
-

--- a/frontend/tests/startup-state.test.mjs
+++ b/frontend/tests/startup-state.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldRefreshSettingsForStartupState } from "../node_modules/.cache/cs2-highlight-tool-backend-tests/app/startup-state.js";
+
+function state(mode, config = {}) {
+  return { mode, config };
+}
+
+test("refreshes an already-loaded settings store when detection completes during startup", () => {
+  assert.equal(
+    shouldRefreshSettingsForStartupState(
+      "startup",
+      {},
+      state("startup", {
+        ffmpeg_detected_preset: "n1",
+        ffmpeg_detected_encoders: ["hevc_nvenc", "libx264"],
+        ffmpeg_detected_at: "2026-09-09T10:00:00Z",
+      }),
+      true,
+    ),
+    true,
+  );
+});
+
+test("refreshes on entering main even when the detection cache did not change", () => {
+  const detected = {
+    ffmpeg_detected_preset: "n1",
+    ffmpeg_detected_encoders: ["hevc_nvenc", "libx264"],
+    ffmpeg_detected_at: "2026-09-09T10:00:00Z",
+  };
+
+  assert.equal(shouldRefreshSettingsForStartupState("startup", detected, state("main", detected), true), true);
+});
+
+test("does not refresh before settings have completed their initial load", () => {
+  assert.equal(
+    shouldRefreshSettingsForStartupState(
+      "startup",
+      {},
+      state("startup", { ffmpeg_detected_preset: "n1" }),
+      false,
+    ),
+    false,
+  );
+});
+
+test("does not refresh while the workspace is being reset", () => {
+  assert.equal(
+    shouldRefreshSettingsForStartupState(
+      "main",
+      { ffmpeg_detected_preset: "n1" },
+      state("workspace_init", {}),
+      true,
+    ),
+    false,
+  );
+});

--- a/frontend/tsconfig.backend-runtime.json
+++ b/frontend/tsconfig.backend-runtime.json
@@ -18,6 +18,7 @@
   "files": [
     "src/global.d.ts",
     "src/shared/backend/adapter.ts",
+    "src/app/startup-state.ts",
     "src/domains/settings/settings-state.ts",
     "src/domains/clip-selection/selection-logic.ts",
     "src/domains/production/jobs.ts",

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -52,6 +52,9 @@ export namespace app {
 	    edit_fps: number;
 	    edit_quality: string;
 	    video_preset: string;
+	    effective_video_preset?: string;
+	    effective_video_encoder?: string;
+	    effective_video_status?: string;
 	    launch_resolution: string;
 	    record_output_dir: string;
 	    enable_spec_show_xray_zero: boolean;
@@ -82,6 +85,9 @@ export namespace app {
 	        this.edit_fps = source["edit_fps"];
 	        this.edit_quality = source["edit_quality"];
 	        this.video_preset = source["video_preset"];
+	        this.effective_video_preset = source["effective_video_preset"];
+	        this.effective_video_encoder = source["effective_video_encoder"];
+	        this.effective_video_status = source["effective_video_status"];
 	        this.launch_resolution = source["launch_resolution"];
 	        this.record_output_dir = source["record_output_dir"];
 	        this.enable_spec_show_xray_zero = source["enable_spec_show_xray_zero"];

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -31,7 +31,7 @@
 
 ## 设置、生成与游戏环境
 
-- 新设置核对配置默认值/兼容处理、Get/Save DTO、生成逻辑及前端类型/控件；关闭命令开关时不生成命令或重置命令。
+- 新设置核对配置默认值/兼容处理、Get/Save DTO、生成逻辑及前端类型/控件；关闭命令开关时不生成命令或重置命令。编码设置的 `effective_video_preset`、`effective_video_encoder`、`effective_video_status` 仅作为 Get/Save 响应的只读探测结果，不能覆盖持久化的 `video_preset` 用户策略。
 - `pov_radar_enabled` 不得与 `pov_hud_enabled` 的 VPK/gameinfo 生命周期联动；`sky_blackout` 不得联动关闭云层。
 - `primary_view`、单片段覆盖和整局 POV 的语义遵循根文件。主视角是选中玩家视角，不能固定为 killer；`include_killer` 缺省 true 的兼容性须保留。
 - 录制 take plan/history 的 `tick_rate`、`record_start_tick`、`record_end_tick`、`kill_offsets_seconds` 只作为后续剪辑的可选观测元数据；插件动作和原有 source window 保持不变。最终视频旁的 `.fastedit.json` 只能 best-effort 写入，不能让成功录制失败。

--- a/internal/app/app_clips_test.go
+++ b/internal/app/app_clips_test.go
@@ -727,6 +727,49 @@ func TestClipActionSettings_GetAndSave(t *testing.T) {
 	}
 }
 
+func TestClipSettings_ReportsEffectiveAutoProfileWithoutPersistingItAsUserChoice(t *testing.T) {
+	exeDir := t.TempDir()
+	cfg := config.Default(exeDir)
+	cfg.VideoPreset = config.DefaultVideoPreset
+	cfg.FFmpegDetectedPreset = "n1"
+	cfg.FFmpegDetectedEncoders = []string{"hevc_nvenc", "libx264"}
+	cfg.FFmpegDetectedAt = "2026-09-09T00:00:00Z"
+	if err := config.Save(filepath.Join(exeDir, "config.json"), cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	app := &App{exeDir: exeDir}
+	settings, err := app.GetClipSettings()
+	if err != nil {
+		t.Fatalf("GetClipSettings: %v", err)
+	}
+	if settings.VideoPreset != "auto" {
+		t.Fatalf("user preset = %q, want auto", settings.VideoPreset)
+	}
+	if settings.EffectiveVideoPreset != "n1" || settings.EffectiveVideoEncoder != "hevc_nvenc" {
+		t.Fatalf("effective profile = %+v, want n1/hevc_nvenc", settings)
+	}
+	if settings.EffectiveVideoStatus != "ready" {
+		t.Fatalf("effective status = %q, want ready", settings.EffectiveVideoStatus)
+	}
+
+	saved, err := app.SaveClipSettings(*settings)
+	if err != nil {
+		t.Fatalf("SaveClipSettings: %v", err)
+	}
+	if saved.VideoPreset != "auto" || saved.EffectiveVideoPreset != "n1" || saved.EffectiveVideoEncoder != "hevc_nvenc" {
+		t.Fatalf("saved settings = %+v, want auto request with n1/hevc_nvenc effective profile", saved)
+	}
+
+	reloadedCfg, err := config.LoadOrCreate(filepath.Join(exeDir, "config.json"), exeDir)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if reloadedCfg.VideoPreset != "auto" {
+		t.Fatalf("persisted user preset = %q, want auto", reloadedCfg.VideoPreset)
+	}
+}
+
 func TestClipSettings_GetAndSave(t *testing.T) {
 	exeDir := t.TempDir()
 	app := &App{exeDir: exeDir}

--- a/internal/app/clip_settings.go
+++ b/internal/app/clip_settings.go
@@ -11,29 +11,32 @@ import (
 )
 
 type ClipSettings struct {
-	KillerPreSeconds   float64 `json:"killer_pre_seconds"`
-	KillerPostSeconds  float64 `json:"killer_post_seconds"`
-	VictimPreSeconds   float64 `json:"victim_pre_seconds"`
-	VictimPostSeconds  float64 `json:"victim_post_seconds"`
-	AutoAddVictimView  bool    `json:"auto_add_victim_view"`
-	EnableVoice        bool    `json:"enable_voice"`
-	RecordFPS          int     `json:"record_fps"`
-	RecordQuality      string  `json:"record_quality"`
-	EditFPS            int     `json:"edit_fps"`
-	EditQuality        string  `json:"edit_quality"`
-	VideoPreset        string  `json:"video_preset"`
-	LaunchResolution   string  `json:"launch_resolution"`
-	RecordOutputDir    string  `json:"record_output_dir"`
-	EnableSpecShowXray bool    `json:"enable_spec_show_xray_zero"`
-	HideAllUI          bool    `json:"hide_all_ui"`
-	HidePlayerAvatars  bool    `json:"hide_player_avatars"`
-	UseShoulderCamera  bool    `json:"use_shoulder_camera"`
-	PovHudEnabled      bool    `json:"pov_hud_enabled"`
-	PovRadarEnabled    bool    `json:"pov_radar_enabled"`
-	SkyBlackout        bool    `json:"sky_blackout"`
-	DisableClouds      bool    `json:"disable_clouds"`
-	KillFeedLifetime   int     `json:"kill_feed_lifetime"`
-	BlockKillFeed      bool    `json:"block_kill_feed"`
+	KillerPreSeconds      float64 `json:"killer_pre_seconds"`
+	KillerPostSeconds     float64 `json:"killer_post_seconds"`
+	VictimPreSeconds      float64 `json:"victim_pre_seconds"`
+	VictimPostSeconds     float64 `json:"victim_post_seconds"`
+	AutoAddVictimView     bool    `json:"auto_add_victim_view"`
+	EnableVoice           bool    `json:"enable_voice"`
+	RecordFPS             int     `json:"record_fps"`
+	RecordQuality         string  `json:"record_quality"`
+	EditFPS               int     `json:"edit_fps"`
+	EditQuality           string  `json:"edit_quality"`
+	VideoPreset           string  `json:"video_preset"`
+	EffectiveVideoPreset  string  `json:"effective_video_preset,omitempty"`
+	EffectiveVideoEncoder string  `json:"effective_video_encoder,omitempty"`
+	EffectiveVideoStatus  string  `json:"effective_video_status,omitempty"`
+	LaunchResolution      string  `json:"launch_resolution"`
+	RecordOutputDir       string  `json:"record_output_dir"`
+	EnableSpecShowXray    bool    `json:"enable_spec_show_xray_zero"`
+	HideAllUI             bool    `json:"hide_all_ui"`
+	HidePlayerAvatars     bool    `json:"hide_player_avatars"`
+	UseShoulderCamera     bool    `json:"use_shoulder_camera"`
+	PovHudEnabled         bool    `json:"pov_hud_enabled"`
+	PovRadarEnabled       bool    `json:"pov_radar_enabled"`
+	SkyBlackout           bool    `json:"sky_blackout"`
+	DisableClouds         bool    `json:"disable_clouds"`
+	KillFeedLifetime      int     `json:"kill_feed_lifetime"`
+	BlockKillFeed         bool    `json:"block_kill_feed"`
 }
 
 type ClipActionSettings struct {
@@ -107,6 +110,7 @@ func (a *App) GetClipSettings() (*ClipSettings, error) {
 		KillFeedLifetime:   cfg.KillFeedLifetime,
 		BlockKillFeed:      cfg.BlockKillFeed,
 	})
+	decorateEffectiveVideoSettings(&settings, cfg)
 	actionSettings := config.ResolveClipActionSettings(cfg)
 	settings.EnableVoice = actionSettings.EnableVoiceIndices && actionSettings.EnableVoiceIndicesH
 	return &settings, nil
@@ -115,7 +119,7 @@ func (a *App) GetClipSettings() (*ClipSettings, error) {
 func (a *App) SaveClipSettings(input ClipSettings) (*ClipSettings, error) {
 	settings := normalizeClipSettings(input)
 	settings.RecordOutputDir = a.fixedRecordOutputDir()
-	if _, err := a.updateConfig(func(cfg *config.Config) error {
+	updatedCfg, err := a.updateConfig(func(cfg *config.Config) error {
 		cfg.KillerPreSeconds = settings.KillerPreSeconds
 		cfg.KillerPostSeconds = settings.KillerPostSeconds
 		cfg.VictimPreSeconds = settings.VictimPreSeconds
@@ -150,9 +154,11 @@ func (a *App) SaveClipSettings(input ClipSettings) (*ClipSettings, error) {
 		}
 		config.SetClipActionSettings(cfg, actionSettings)
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
+	decorateEffectiveVideoSettings(&settings, updatedCfg)
 	return &settings, nil
 }
 
@@ -235,6 +241,9 @@ func normalizeClipSettings(input ClipSettings) ClipSettings {
 		settings.EditQuality = config.DefaultEditQuality
 	}
 	settings.VideoPreset = ffmpegprofile.NormalizeUserPreset(settings.VideoPreset)
+	settings.EffectiveVideoPreset = ""
+	settings.EffectiveVideoEncoder = ""
+	settings.EffectiveVideoStatus = ""
 	settings.LaunchResolution = strings.TrimSpace(settings.LaunchResolution)
 	if !config.IsSupportedLaunchResolution(settings.LaunchResolution) {
 		settings.LaunchResolution = config.DefaultLaunchResolution
@@ -250,6 +259,23 @@ func normalizeClipSettings(input ClipSettings) ClipSettings {
 		settings.KillFeedLifetime = config.MaxKillFeedLifetime
 	}
 	return settings
+}
+
+func decorateEffectiveVideoSettings(settings *ClipSettings, cfg *config.Config) {
+	if settings == nil {
+		return
+	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	resolved := ffmpegprofile.ResolveVideoPreset(
+		settings.VideoPreset,
+		cfg.FFmpegDetectedPreset,
+		cfg.FFmpegDetectedEncoders,
+	)
+	settings.EffectiveVideoPreset = resolved.EffectivePreset
+	settings.EffectiveVideoEncoder = resolved.Encoder
+	settings.EffectiveVideoStatus = resolved.Status
 }
 
 func normalizeClipActionSettings(input ClipActionSettings) ClipActionSettings {

--- a/internal/ffmpegprofile/ffmpegprofile_test.go
+++ b/internal/ffmpegprofile/ffmpegprofile_test.go
@@ -19,6 +19,49 @@ func TestNormalizeUserPreset(t *testing.T) {
 	}
 }
 
+func TestResolveVideoPreset_PreservesAutoAndReportsEffectiveEncoder(t *testing.T) {
+	resolved := ResolveVideoPreset(UserPresetAuto, UserPresetN1, []string{"hevc_nvenc", "libx264"})
+	if resolved.RequestedPreset != UserPresetAuto {
+		t.Fatalf("requested preset = %q, want auto", resolved.RequestedPreset)
+	}
+	if resolved.EffectivePreset != UserPresetN1 || resolved.Encoder != "hevc_nvenc" {
+		t.Fatalf("effective profile = %+v, want n1/hevc_nvenc", resolved)
+	}
+	if resolved.Status != VideoPresetStatusReady {
+		t.Fatalf("status = %q, want ready", resolved.Status)
+	}
+}
+
+func TestResolveVideoPreset_ReportsHardwareH264Fallback(t *testing.T) {
+	resolved := ResolveVideoPreset(UserPresetAuto, "", []string{"h264_nvenc", "libx264"})
+	if resolved.EffectivePreset != internalPresetN1H264 || resolved.Encoder != "h264_nvenc" {
+		t.Fatalf("effective profile = %+v, want n1_h264/h264_nvenc", resolved)
+	}
+	if resolved.Status != VideoPresetStatusReady {
+		t.Fatalf("status = %q, want ready", resolved.Status)
+	}
+}
+
+func TestResolveVideoPreset_MarksMissingDetectionPending(t *testing.T) {
+	resolved := ResolveVideoPreset(UserPresetAuto, "", nil)
+	if resolved.EffectivePreset != UserPresetC1 || resolved.Encoder != "libx264" {
+		t.Fatalf("fallback profile = %+v, want c1/libx264", resolved)
+	}
+	if resolved.Status != VideoPresetStatusPending {
+		t.Fatalf("status = %q, want pending", resolved.Status)
+	}
+}
+
+func TestResolveVideoPresetManualUsesRequestedProfile(t *testing.T) {
+	resolved := ResolveVideoPreset(UserPresetN1, UserPresetA1, []string{"hevc_amf"})
+	if resolved.RequestedPreset != UserPresetN1 || resolved.EffectivePreset != UserPresetN1 || resolved.Encoder != "hevc_nvenc" {
+		t.Fatalf("manual resolution = %+v, want n1/hevc_nvenc", resolved)
+	}
+	if resolved.Status != VideoPresetStatusManual {
+		t.Fatalf("status = %q, want manual", resolved.Status)
+	}
+}
+
 func TestResolveProfile_AutoPriority(t *testing.T) {
 	caps := CapabilitiesFromEncoders([]string{"h264_nvenc", "libx264"})
 	resolved := ResolveProfile(UserPresetAuto, caps)

--- a/internal/ffmpegprofile/resolve.go
+++ b/internal/ffmpegprofile/resolve.go
@@ -8,6 +8,76 @@ type Resolution struct {
 	TriedProfileIDs []string
 }
 
+// VideoPresetResolution describes the profile that will actually be used for
+// a requested preset. The requested value remains "auto" when the user chose
+// automatic selection; EffectivePreset/Encoder are only presentation and
+// runtime-resolution metadata.
+type VideoPresetResolution struct {
+	RequestedPreset string
+	EffectivePreset string
+	Encoder         string
+	Status          string
+}
+
+const (
+	VideoPresetStatusManual  = "manual"
+	VideoPresetStatusReady   = "ready"
+	VideoPresetStatusPending = "pending"
+)
+
+// ResolveVideoPreset resolves the same effective profile used by recording and
+// editing, while preserving the user's requested preset. A missing detection
+// cache still returns the c1 runtime fallback, but marks it as pending so the
+// UI does not present that fallback as a completed hardware detection.
+func ResolveVideoPreset(userPreset string, detectedPreset string, detectedEncoders []string) VideoPresetResolution {
+	requested := NormalizeUserPreset(userPreset)
+	if requested != UserPresetAuto {
+		profile, ok := ProfileByID(requested)
+		if !ok {
+			profile, _ = ProfileByID(UserPresetC1)
+		}
+		return VideoPresetResolution{
+			RequestedPreset: requested,
+			EffectivePreset: profile.ID,
+			Encoder:         profile.Encoder,
+			Status:          VideoPresetStatusManual,
+		}
+	}
+
+	if profile, ok := ProfileByID(detectedPreset); ok && strings.TrimSpace(profile.Encoder) != "" {
+		return VideoPresetResolution{
+			RequestedPreset: requested,
+			EffectivePreset: profile.ID,
+			Encoder:         profile.Encoder,
+			Status:          VideoPresetStatusReady,
+		}
+	}
+
+	caps := CapabilitiesFromEncoders(detectedEncoders)
+	if !caps.IsEmpty() {
+		resolved := ResolveProfile(UserPresetAuto, caps)
+		if strings.TrimSpace(resolved.SelectedProfile.ID) != "" {
+			return VideoPresetResolution{
+				RequestedPreset: requested,
+				EffectivePreset: resolved.SelectedProfile.ID,
+				Encoder:         resolved.SelectedProfile.Encoder,
+				Status:          VideoPresetStatusReady,
+			}
+		}
+	}
+
+	fallback, ok := ProfileByID(UserPresetC1)
+	if !ok {
+		fallback = Profile{ID: UserPresetC1, Encoder: "libx264"}
+	}
+	return VideoPresetResolution{
+		RequestedPreset: requested,
+		EffectivePreset: fallback.ID,
+		Encoder:         fallback.Encoder,
+		Status:          VideoPresetStatusPending,
+	}
+}
+
 func ResolveProfile(userPreset string, caps Capabilities) Resolution {
 	normalized := NormalizeUserPreset(userPreset)
 	order := ResolveOrder(normalized)

--- a/internal/plugingen/helpers.go
+++ b/internal/plugingen/helpers.go
@@ -92,20 +92,15 @@ func BuildBatchRecordSubDirs(demoPaths []string) []string {
 // ResolvePluginVideoPreset resolves the effective video preset to use.
 // If userPreset is "auto", it derives the best preset from cfg's detected capabilities.
 func ResolvePluginVideoPreset(userPreset string, cfg *config.Config) string {
-	normalized := ffmpegprofile.NormalizeUserPreset(userPreset)
-	if normalized != ffmpegprofile.UserPresetAuto {
-		return normalized
+	var detectedPreset string
+	var detectedEncoders []string
+	if cfg != nil {
+		detectedPreset = cfg.FFmpegDetectedPreset
+		detectedEncoders = cfg.FFmpegDetectedEncoders
 	}
-	if cfg == nil {
+	resolved := ffmpegprofile.ResolveVideoPreset(userPreset, detectedPreset, detectedEncoders)
+	if strings.TrimSpace(resolved.EffectivePreset) == "" {
 		return ffmpegprofile.UserPresetC1
 	}
-	if detected, ok := ffmpegprofile.ProfileByID(cfg.FFmpegDetectedPreset); ok && strings.TrimSpace(detected.ID) != "" {
-		return detected.ID
-	}
-	caps := ffmpegprofile.CapabilitiesFromEncoders(cfg.FFmpegDetectedEncoders)
-	resolved := ffmpegprofile.ResolveProfile(ffmpegprofile.UserPresetAuto, caps)
-	if strings.TrimSpace(resolved.SelectedProfile.ID) == "" {
-		return ffmpegprofile.UserPresetC1
-	}
-	return resolved.SelectedProfile.ID
+	return resolved.EffectivePreset
 }

--- a/internal/plugingen/helpers_test.go
+++ b/internal/plugingen/helpers_test.go
@@ -78,4 +78,7 @@ func TestResolvePluginVideoPreset_AutoUsesDetectedManualKeepsChoice(t *testing.T
 	if got := ResolvePluginVideoPreset("auto", nil); got != "c1" {
 		t.Fatalf("auto with nil cfg should fall back to c1, got=%q", got)
 	}
+	if got := ResolvePluginVideoPreset("n1", nil); got != "n1" {
+		t.Fatalf("manual preset with nil cfg should keep user choice, got=%q", got)
+	}
 }


### PR DESCRIPTION
Summary: preserve video_preset=auto while exposing the effective encoder; refresh loaded settings when detection completes during startup and when entering main; add startup timing regression tests. Validation: go test ./...; cd frontend && npm test (50/50); cd frontend && npm run build; wails build; git diff --check. Windows CS2/HLAE real-machine verification remains pending.