### PR TITLE
feat(envsetup): 组件下载双路并行竞速与取消仲裁

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ CS2 Demo 导入、片段选择、自动录制与后期拼接的 Windows 桌面�
 - 状态源为 `GetStartupState` 和 `startup_state_changed`，模型见 `internal/envsetup/state.go`。`mode` 为 `workspace_init|startup|main`；`phase` 为 `detecting_source|waiting_source|running_tasks|ready`；二者不可混用。
 - 组件 ID：`hlae`、`plugin`、`ffmpeg`、`cs2`。组件/启动状态：`pending`、`checking`、`downloading`、`installing`、`ready`、`warning`、`failed`、`needs_action`。
 - 启动时实时 GeoIP 检测，统一更新源固定为 `github`，地区结果不持久化。先获取统一 Release 快照，再检查软件自身更新；确认 `self_update.available=true` 时必须先更新软件，不启动组件检查/安装。自更新检查失败保持非致命语义。
-- 组件下载顺序：CN 或 GeoIP 失败/为空时 `url → mirror_url`；非 CN 仅 `github_url`。失败直接报错，不恢复多源自动回退或 gh-proxy 终极兜底。统一源失败可使用本地已安装组件并标记 warning，不伪造远端成功。
+- 组件下载策略：CN 或 GeoIP 失败/为空时，`mirror_url` 与 `url` 并行竞速，先成功完成的链路胜出并取消另一条；非 CN 仅 `github_url`。竞速全部失败才报错，不恢复多源自动回退或 gh-proxy 终极兜底。统一源失败可使用本地已安装组件并标记 warning，不伪造远端成功。
 - HLAE、插件本地版本均来自各自安装目录 `changelog.xml` 首个 `<version>`，不以配置持久化版本为真值。
 - `StartupState.ads[]` 仅包含有效的 `main_steps_top_banner` Sponsored Card，展示字段为 `click_url/sponsor/title/rich_html/image_url/image_alt`；点击走外部浏览器，广告失败不得阻断启动。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Import alias: Use `@/` for `frontend/src/**` imports.
 
 - **HLAE/plugin local version:** Must be read from installation directory's `changelog.xml` (first `<version>` element), not from persisted `config.json`.
 - **Logging:** All startup logs go through `internal/logging` (slog adapter). Sensitive values (tokens, auth headers, home paths) are automatically sanitized. Trace fields: `component`, `stage`, `action`, `source`, `attempt`, `error`, `elapsed_ms`.
-- **Unified release source:** A single release API snapshot is fetched at startup and consumed by all components. GitHub download URLs are rewritten via gh-proxy only when `country_code=CN`; non-CN goes direct. No multi-source fallback.
+- **Unified release source:** A single release API snapshot is fetched at startup and consumed by all components. For CN or unknown GeoIP, component downloads race `mirror_url` and `url` in parallel and the first completed link wins; non-CN uses `github_url` only. No update-source-level fallback.
 - **Concurrency:** Use existing `mu`/`configMu` mutexes for `Service.state`, `Service.logs`, `Service.config`. No blocking I/O inside locks. Always call `emitState()` after state mutation.
 - **Wails binding boundary:** Frontend accesses all backend methods via `window.go.app.App.*` and receives push events via `runtime.EventsOn(...)`. New Wails-exposed methods are stable public contracts — do not rename without coordination.
 

--- a/internal/envsetup/cancel_download_test.go
+++ b/internal/envsetup/cancel_download_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"cs2-highlight-tool-v2/internal/download"
 	"cs2-highlight-tool-v2/internal/release"
@@ -34,9 +35,11 @@ func findStepStatusForTest(state StartupState, componentID string) string {
 	return ""
 }
 
-func TestDownloadAndInstallWithFallbackCancelStopsRemainingCandidates(t *testing.T) {
+func TestDownloadAndInstallWithFallbackCancelStopsRace(t *testing.T) {
 	firstStarted := make(chan struct{})
-	secondHit := make(chan struct{}, 1)
+	secondStarted := make(chan struct{})
+	firstCanceled := make(chan struct{})
+	secondCanceled := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/first.zip":
@@ -46,9 +49,15 @@ func TestDownloadAndInstallWithFallbackCancelStopsRemainingCandidates(t *testing
 			}
 			close(firstStarted)
 			<-r.Context().Done()
+			close(firstCanceled)
 		case "/second.zip":
-			secondHit <- struct{}{}
-			_, _ = w.Write([]byte("second"))
+			_, _ = w.Write([]byte("partial"))
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			close(secondStarted)
+			<-r.Context().Done()
+			close(secondCanceled)
 		default:
 			http.NotFound(w, r)
 		}
@@ -72,22 +81,37 @@ func TestDownloadAndInstallWithFallbackCancelStopsRemainingCandidates(t *testing
 		},
 	}
 
+	installCalled := make(chan struct{}, 1)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- svc.downloadAndInstallWithFallback(componentHLAE, "v2.0.0", candidates, func(path string) error {
+			installCalled <- struct{}{}
 			return nil
 		})
 	}()
 
+	// 竞速会同时启动两条链路；确认都已进入下载后再取消。
 	<-firstStarted
+	<-secondStarted
 	svc.CancelStartupDownload(componentHLAE)
+
 	err := <-errCh
 	if !errors.Is(err, download.ErrCanceled) {
 		t.Fatalf("downloadAndInstallWithFallback error = %v, want ErrCanceled", err)
 	}
+	for name, canceled := range map[string]chan struct{}{
+		"first":  firstCanceled,
+		"second": secondCanceled,
+	} {
+		select {
+		case <-canceled:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s download was not canceled", name)
+		}
+	}
 	select {
-	case <-secondHit:
-		t.Fatal("second candidate was attempted after cancel")
+	case <-installCalled:
+		t.Fatal("install was called after cancel")
 	default:
 	}
 }

--- a/internal/envsetup/cancel_download_test.go
+++ b/internal/envsetup/cancel_download_test.go
@@ -115,3 +115,89 @@ func TestDownloadAndInstallWithFallbackCancelStopsRace(t *testing.T) {
 	default:
 	}
 }
+
+func TestCancelStartupDownloadIgnoresFinishedGroup(t *testing.T) {
+	svc := New(t.TempDir(), "1.0.0")
+	svc.Startup(nil)
+	active, _, cancelCause := svc.beginDownloadGroup(componentHLAE)
+	defer svc.endDownloadGroup(componentHLAE, active)
+	// 模拟竞速已经提交胜者：此时再取消不应把步骤改成 failed。
+	cancelCause(errDownloadFinished)
+
+	state := svc.CancelStartupDownload(componentHLAE)
+	if got := findStepStatusForTest(state, componentHLAE); got == statusFailed {
+		t.Fatalf("status = %s, want not failed after race already finished", got)
+	}
+}
+
+func TestDownloadAndInstallWithFallback_UserCancelWinsOverCompletedDownload(t *testing.T) {
+	svc := New(t.TempDir(), "1.0.0")
+	svc.Startup(nil)
+
+	fastServed := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/fast.zip":
+			// 响应体完整写出后、连接关闭前触发用户取消。
+			// 客户端要等到 EOF 才会产生成功结果，因此成功结果必然在取消之后才入队。
+			_, _ = w.Write([]byte("fast-payload"))
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			svc.CancelStartupDownload(componentHLAE)
+			close(fastServed)
+		case "/slow.zip":
+			_, _ = w.Write([]byte("partial"))
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			<-r.Context().Done()
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	candidates := []releaseAssetCandidate{
+		{
+			Source:   DownloadSourceGitHub,
+			Asset:    release.Asset{Name: "hlae_2_0_0.zip"},
+			AssetURL: server.URL + "/fast.zip",
+			URLKind:  urlKindDirect,
+		},
+		{
+			Source:   DownloadSourceGitHub,
+			Asset:    release.Asset{Name: "hlae_2_0_0.zip"},
+			AssetURL: server.URL + "/slow.zip",
+			URLKind:  urlKindMirror,
+		},
+	}
+
+	installCalled := make(chan struct{}, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- svc.downloadAndInstallWithFallback(componentHLAE, "v2.0.0", candidates, func(path string) error {
+			installCalled <- struct{}{}
+			return nil
+		})
+	}()
+
+	select {
+	case <-fastServed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("fast download did not serve")
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, download.ErrCanceled) {
+			t.Fatalf("downloadAndInstallWithFallback error = %v, want ErrCanceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("downloadAndInstallWithFallback did not return")
+	}
+	select {
+	case <-installCalled:
+		t.Fatal("install was called after user cancel")
+	default:
+	}
+}

--- a/internal/envsetup/release_fallback.go
+++ b/internal/envsetup/release_fallback.go
@@ -1,11 +1,14 @@
 package envsetup
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"cs2-highlight-tool-v2/internal/download"
 	"cs2-highlight-tool-v2/internal/endpoints"
@@ -104,7 +107,39 @@ func (s *Service) downloadAndInstallWithFallback(componentID string, latest stri
 	if len(candidates) == 0 {
 		return fmt.Errorf("没有可用下载候选")
 	}
+	// 单候选保持原有顺序语义；多候选（CN / GeoIP 为空时的 mirror + url）并行竞速，
+	// 先下载完成的链路胜出，避免“慢但不断流”的链路拖住整个下载。
+	if len(candidates) == 1 {
+		return s.downloadAndInstallSequential(componentID, latest, candidates, install)
+	}
 
+	winner, winnerPath, raceFailures, err := s.raceDownloadCandidates(componentID, latest, candidates)
+	if err != nil {
+		return err
+	}
+	if installErr := install(winnerPath); installErr != nil {
+		failures := append([]string(nil), raceFailures...)
+		failures = append(failures, fmt.Sprintf("%s(%s) 安装失败: %v", strings.ToUpper(string(winner.Source)), winner.URLKind, installErr))
+		remaining := make([]releaseAssetCandidate, 0, len(candidates)-1)
+		for _, candidate := range candidates {
+			if candidate.AssetURL == winner.AssetURL {
+				continue
+			}
+			remaining = append(remaining, candidate)
+		}
+		if seqErr := s.downloadAndInstallSequential(componentID, latest, remaining, install); seqErr != nil {
+			if errors.Is(seqErr, download.ErrCanceled) {
+				return seqErr
+			}
+			failures = append(failures, seqErr.Error())
+			return fmt.Errorf("%s", strings.Join(failures, " | "))
+		}
+		return nil
+	}
+	return nil
+}
+
+func (s *Service) downloadAndInstallSequential(componentID string, latest string, candidates []releaseAssetCandidate, install func(path string) error) error {
 	failures := make([]string, 0, len(candidates))
 	attempt := 0
 	for _, candidate := range candidates {
@@ -139,6 +174,155 @@ func (s *Service) downloadAndInstallWithFallback(componentID string, latest stri
 		return fmt.Errorf("所有下载回退均失败")
 	}
 	return fmt.Errorf("%s", strings.Join(failures, " | "))
+}
+
+type downloadRaceResult struct {
+	index int
+	err   error
+}
+
+// raceDownloadCandidates 并行下载所有候选链接，第一个成功完成的胜出，其余立即取消并清理。
+// 只有全部候选都失败时才返回错误；用户取消返回 download.ErrCanceled。
+func (s *Service) raceDownloadCandidates(componentID string, latest string, candidates []releaseAssetCandidate) (releaseAssetCandidate, string, []string, error) {
+	active, ctx, cancelCause := s.beginDownloadGroup(componentID)
+	defer s.endDownloadGroup(componentID, active)
+	defer cancelCause(errDownloadRaceFinished)
+	defer s.emitProgress(componentID, false, 0, false)
+
+	targetPaths := make([]string, len(candidates))
+	for i, candidate := range candidates {
+		targetPaths[i] = tempAssetPathForCandidate(s.dataDir, componentID, latest, candidate.Asset, candidate.URLKind)
+	}
+
+	progress := &raceProgressTracker{service: s, componentID: componentID}
+	results := make(chan downloadRaceResult, len(candidates))
+	var wg sync.WaitGroup
+	for i, candidate := range candidates {
+		i, candidate := i, candidate
+		s.emitLogWithFields("info", "开始竞速下载组件资产", logFields{
+			Component: componentID,
+			Stage:     "download_fallback",
+			Action:    "race_start",
+			Source:    string(candidate.Source),
+			Attempt:   i + 1,
+			Meta: map[string]string{
+				"url":      candidate.AssetURL,
+				"url_kind": candidate.URLKind,
+			},
+		})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := download.FileWithContext(ctx, candidate.AssetURL, targetPaths[i], progress.report)
+			results <- downloadRaceResult{index: i, err: err}
+		}()
+	}
+
+	failures := make([]string, 0, len(candidates))
+	winner := -1
+	for remaining := len(candidates); remaining > 0; remaining-- {
+		result := <-results
+		if result.err == nil {
+			winner = result.index
+			cancelCause(errDownloadRaceFinished)
+			break
+		}
+		if errors.Is(result.err, download.ErrCanceled) {
+			if errors.Is(context.Cause(ctx), errDownloadCanceledByUser) {
+				cancelCause(errDownloadRaceFinished)
+				wg.Wait()
+				removeDownloadTempFiles(targetPaths)
+				return releaseAssetCandidate{}, "", nil, download.ErrCanceled
+			}
+			// 竞速内部取消（另一条链路已胜出）不算失败。
+			continue
+		}
+		failures = append(failures, fmt.Sprintf("%d/%s(%s) 下载失败: %v", result.index+1, strings.ToUpper(string(candidates[result.index].Source)), candidates[result.index].URLKind, result.err))
+	}
+	wg.Wait()
+
+	if winner < 0 {
+		removeDownloadTempFiles(targetPaths)
+		if len(failures) == 0 {
+			return releaseAssetCandidate{}, "", nil, fmt.Errorf("所有下载回退均失败")
+		}
+		return releaseAssetCandidate{}, "", failures, fmt.Errorf("%s", strings.Join(failures, " | "))
+	}
+
+	// 胜者保留，落败者（包括在胜出瞬间已完成的）全部清理，避免遗留临时文件。
+	for i, path := range targetPaths {
+		if i != winner {
+			_ = os.Remove(path)
+		}
+	}
+	if _, err := os.Stat(targetPaths[winner]); err != nil {
+		return releaseAssetCandidate{}, "", failures, fmt.Errorf("竞速下载完成但文件不存在: %w", err)
+	}
+
+	selected := candidates[winner]
+	s.emitLogWithFields("info", "竞速下载完成，采用先完成的链路", logFields{
+		Component: componentID,
+		Stage:     "download_fallback",
+		Action:    "race_winner",
+		Source:    string(selected.Source),
+		Attempt:   winner + 1,
+		Meta: map[string]string{
+			"url":      selected.AssetURL,
+			"url_kind": selected.URLKind,
+		},
+	})
+	return selected, targetPaths[winner], failures, nil
+}
+
+// raceProgressTracker 只上报当前进度最高的链路，避免两条下载的百分比来回跳动。
+type raceProgressTracker struct {
+	service     *Service
+	componentID string
+
+	mu          sync.Mutex
+	started     bool
+	bestPercent float64
+}
+
+func (t *raceProgressTracker) report(active bool, percent float64, indeterminate bool) {
+	if !active {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if indeterminate {
+		if !t.started {
+			t.started = true
+			t.service.emitProgress(t.componentID, true, 0, true)
+		}
+		return
+	}
+	if !t.started || percent > t.bestPercent {
+		t.started = true
+		if percent > t.bestPercent {
+			t.bestPercent = percent
+		}
+		t.service.emitProgress(t.componentID, true, t.bestPercent, false)
+	}
+}
+
+func removeDownloadTempFiles(paths []string) {
+	for _, path := range paths {
+		_ = os.Remove(path)
+	}
+}
+
+func tempAssetPathForCandidate(dataDir, componentID, latest string, asset release.Asset, urlKind string) string {
+	basePath := tempAssetPath(dataDir, componentID, latest, asset)
+	urlKind = strings.TrimSpace(urlKind)
+	if urlKind == "" {
+		return basePath
+	}
+	ext := filepath.Ext(basePath)
+	if ext == "" {
+		return basePath + "_" + sanitizeFileName(urlKind)
+	}
+	return strings.TrimSuffix(basePath, ext) + "_" + sanitizeFileName(urlKind) + ext
 }
 
 func tempAssetPath(dataDir, componentID, latest string, asset release.Asset) string {

--- a/internal/envsetup/release_fallback.go
+++ b/internal/envsetup/release_fallback.go
@@ -181,12 +181,50 @@ type downloadRaceResult struct {
 	err   error
 }
 
+type raceOutcome struct {
+	winner   int
+	failures []string
+	canceled bool
+}
+
+// awaitRaceOutcome 统一仲裁竞速结果：用户取消优先于任何已入队的成功结果。
+// 取消检查同时放在接收结果前后，覆盖“成功结果已入队、随后用户取消、协调循环才读到该结果”的时序。
+func awaitRaceOutcome(ctx context.Context, results <-chan downloadRaceResult, candidates []releaseAssetCandidate) raceOutcome {
+	outcome := raceOutcome{winner: -1, failures: make([]string, 0, len(candidates))}
+	for remaining := len(candidates); remaining > 0; remaining-- {
+		if isUserCancelCause(ctx) {
+			outcome.canceled = true
+			return outcome
+		}
+		result := <-results
+		if isUserCancelCause(ctx) {
+			outcome.canceled = true
+			return outcome
+		}
+		if result.err == nil {
+			outcome.winner = result.index
+			return outcome
+		}
+		if errors.Is(result.err, download.ErrCanceled) {
+			// 竞速内部取消（另一条链路已胜出）不算失败。
+			continue
+		}
+		outcome.failures = append(outcome.failures, fmt.Sprintf("%d/%s(%s) 下载失败: %v", result.index+1, strings.ToUpper(string(candidates[result.index].Source)), candidates[result.index].URLKind, result.err))
+	}
+	outcome.canceled = isUserCancelCause(ctx)
+	return outcome
+}
+
+func isUserCancelCause(ctx context.Context) bool {
+	return ctx != nil && errors.Is(context.Cause(ctx), errDownloadCanceledByUser)
+}
+
 // raceDownloadCandidates 并行下载所有候选链接，第一个成功完成的胜出，其余立即取消并清理。
 // 只有全部候选都失败时才返回错误；用户取消返回 download.ErrCanceled。
 func (s *Service) raceDownloadCandidates(componentID string, latest string, candidates []releaseAssetCandidate) (releaseAssetCandidate, string, []string, error) {
 	active, ctx, cancelCause := s.beginDownloadGroup(componentID)
 	defer s.endDownloadGroup(componentID, active)
-	defer cancelCause(errDownloadRaceFinished)
+	defer cancelCause(errDownloadFinished)
 	defer s.emitProgress(componentID, false, 0, false)
 
 	targetPaths := make([]string, len(candidates))
@@ -218,29 +256,20 @@ func (s *Service) raceDownloadCandidates(componentID string, latest string, cand
 		}()
 	}
 
-	failures := make([]string, 0, len(candidates))
-	winner := -1
-	for remaining := len(candidates); remaining > 0; remaining-- {
-		result := <-results
-		if result.err == nil {
-			winner = result.index
-			cancelCause(errDownloadRaceFinished)
-			break
-		}
-		if errors.Is(result.err, download.ErrCanceled) {
-			if errors.Is(context.Cause(ctx), errDownloadCanceledByUser) {
-				cancelCause(errDownloadRaceFinished)
-				wg.Wait()
-				removeDownloadTempFiles(targetPaths)
-				return releaseAssetCandidate{}, "", nil, download.ErrCanceled
-			}
-			// 竞速内部取消（另一条链路已胜出）不算失败。
-			continue
-		}
-		failures = append(failures, fmt.Sprintf("%d/%s(%s) 下载失败: %v", result.index+1, strings.ToUpper(string(candidates[result.index].Source)), candidates[result.index].URLKind, result.err))
+	outcome := awaitRaceOutcome(ctx, results, candidates)
+
+	// 统一提交竞速结果：先取消其余链路，再仲裁用户取消是否先于本次提交。
+	// 如果用户取消先发生，即使成功结果已经入队，也必须以取消为准。
+	cancelCause(errDownloadFinished)
+	if outcome.canceled || isUserCancelCause(ctx) {
+		wg.Wait()
+		removeDownloadTempFiles(targetPaths)
+		return releaseAssetCandidate{}, "", nil, download.ErrCanceled
 	}
 	wg.Wait()
 
+	winner := outcome.winner
+	failures := outcome.failures
 	if winner < 0 {
 		removeDownloadTempFiles(targetPaths)
 		if len(failures) == 0 {

--- a/internal/envsetup/release_fallback_test.go
+++ b/internal/envsetup/release_fallback_test.go
@@ -1,10 +1,14 @@
 package envsetup
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"cs2-highlight-tool-v2/internal/release"
 )
@@ -192,5 +196,132 @@ func TestDownloadAndInstallWithFallback_CNDoesNotAttemptGitHubURL(t *testing.T) 
 	}
 	if urlHits != 1 || mirrorHits != 1 || githubHits != 0 {
 		t.Fatalf("hits url=%d mirror=%d github=%d", urlHits, mirrorHits, githubHits)
+	}
+}
+
+func TestDownloadAndInstallWithFallback_RaceUsesFasterCandidate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/slow.zip":
+			// 声明一个远大于实际写入量的长度，确保慢链路不会因为提前 EOF 而胜出。
+			w.Header().Set("Content-Length", "1048576")
+			_, _ = w.Write([]byte("slow"))
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			select {
+			case <-r.Context().Done():
+			case <-time.After(3 * time.Second):
+			}
+		case "/fast.zip":
+			_, _ = w.Write([]byte("fast-payload"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	svc := New(t.TempDir(), "1.0.0")
+	svc.Startup(nil)
+	candidates := []releaseAssetCandidate{
+		{
+			Source:   DownloadSourceGitHub,
+			Asset:    release.Asset{Name: "hlae_2_0_0.zip"},
+			AssetURL: server.URL + "/slow.zip",
+			URLKind:  urlKindMirror,
+		},
+		{
+			Source:   DownloadSourceGitHub,
+			Asset:    release.Asset{Name: "hlae_2_0_0.zip"},
+			AssetURL: server.URL + "/fast.zip",
+			URLKind:  urlKindDirect,
+		},
+	}
+
+	var installedPath string
+	var installedContent string
+	err := svc.downloadAndInstallWithFallback(componentHLAE, "v2.0.0", candidates, func(path string) error {
+		installedPath = path
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		installedContent = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("downloadAndInstallWithFallback error: %v", err)
+	}
+	if !strings.HasSuffix(installedPath, "_"+urlKindDirect+".zip") {
+		t.Fatalf("installed path = %q, want fast direct candidate", installedPath)
+	}
+	if installedContent != "fast-payload" {
+		t.Fatalf("installed content = %q, want fast-payload", installedContent)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(svc.dataDir, "temp"))
+	if err != nil {
+		t.Fatalf("read temp dir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != filepath.Base(installedPath) {
+		t.Fatalf("temp entries = %#v, want only winner %s", entries, filepath.Base(installedPath))
+	}
+}
+
+func TestDownloadAndInstallWithFallback_RaceFallsBackWhenWinnerInstallFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mirror.zip":
+			_, _ = w.Write([]byte("mirror-payload"))
+		case "/url.zip":
+			_, _ = w.Write([]byte("url-payload"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	svc := New(t.TempDir(), "1.0.0")
+	svc.Startup(nil)
+	candidates := []releaseAssetCandidate{
+		{
+			Source:   DownloadSourceGitHub,
+			Asset:    release.Asset{Name: "hlae_2_0_0.zip"},
+			AssetURL: server.URL + "/mirror.zip",
+			URLKind:  urlKindMirror,
+		},
+		{
+			Source:   DownloadSourceGitHub,
+			Asset:    release.Asset{Name: "hlae_2_0_0.zip"},
+			AssetURL: server.URL + "/url.zip",
+			URLKind:  urlKindDirect,
+		},
+	}
+
+	installPaths := make([]string, 0, 2)
+	installedContent := ""
+	err := svc.downloadAndInstallWithFallback(componentHLAE, "v2.0.0", candidates, func(path string) error {
+		installPaths = append(installPaths, path)
+		if len(installPaths) == 1 {
+			return errors.New("模拟安装失败")
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		installedContent = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("downloadAndInstallWithFallback error: %v", err)
+	}
+	if len(installPaths) != 2 {
+		t.Fatalf("install calls = %d, want 2", len(installPaths))
+	}
+	if base := filepath.Base(installPaths[1]); base != "hlae_v2.0.0.zip" {
+		t.Fatalf("fallback install path = %q, want unsuffixed temp path", installPaths[1])
+	}
+	if installedContent != "mirror-payload" && installedContent != "url-payload" {
+		t.Fatalf("installed content = %q, want one of the candidate payloads", installedContent)
 	}
 }

--- a/internal/envsetup/release_fallback_test.go
+++ b/internal/envsetup/release_fallback_test.go
@@ -1,6 +1,7 @@
 package envsetup
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -323,5 +324,39 @@ func TestDownloadAndInstallWithFallback_RaceFallsBackWhenWinnerInstallFails(t *t
 	}
 	if installedContent != "mirror-payload" && installedContent != "url-payload" {
 		t.Fatalf("installed content = %q, want one of the candidate payloads", installedContent)
+	}
+}
+
+func TestAwaitRaceOutcome_UserCancelWinsOverQueuedSuccess(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	results := make(chan downloadRaceResult, 1)
+	results <- downloadRaceResult{index: 0}
+	cancel(errDownloadCanceledByUser)
+
+	outcome := awaitRaceOutcome(ctx, results, []releaseAssetCandidate{
+		{Source: DownloadSourceGitHub, URLKind: urlKindDirect},
+	})
+	if !outcome.canceled {
+		t.Fatalf("outcome = %#v, want canceled", outcome)
+	}
+	if outcome.winner != -1 {
+		t.Fatalf("winner = %d, want -1", outcome.winner)
+	}
+}
+
+func TestAwaitRaceOutcome_ReturnsQueuedSuccess(t *testing.T) {
+	ctx := context.Background()
+	results := make(chan downloadRaceResult, 1)
+	results <- downloadRaceResult{index: 1}
+
+	outcome := awaitRaceOutcome(ctx, results, []releaseAssetCandidate{
+		{Source: DownloadSourceGitHub, URLKind: urlKindDirect},
+		{Source: DownloadSourceGitHub, URLKind: urlKindMirror},
+	})
+	if outcome.canceled {
+		t.Fatalf("outcome = %#v, want not canceled", outcome)
+	}
+	if outcome.winner != 1 {
+		t.Fatalf("winner = %d, want 1", outcome.winner)
 	}
 }

--- a/internal/envsetup/service.go
+++ b/internal/envsetup/service.go
@@ -39,6 +39,7 @@ type Service struct {
 
 type activeDownloadCancel struct {
 	cancel context.CancelFunc
+	ctx    context.Context
 }
 
 func New(exeDir string, version string) *Service {

--- a/internal/envsetup/service_actions.go
+++ b/internal/envsetup/service_actions.go
@@ -118,6 +118,14 @@ func (s *Service) CancelStartupDownload(componentID string) StartupState {
 	}
 
 	active.cancel()
+	if !active.canceledByUser() {
+		// 竞速已经提交胜者或下载已经完成，本次取消不再生效，避免界面先显示“已取消”又继续安装。
+		s.emitLogWithFields("info", "当前组件下载已结束，忽略取消请求", logFields{
+			Component: componentID,
+			Action:    "cancel_download",
+		})
+		return s.GetStartupState()
+	}
 	s.updateStep(componentID, func(step *ComponentStatus) {
 		step.Status = statusFailed
 		step.Error = downloadCanceledMessage

--- a/internal/envsetup/service_state.go
+++ b/internal/envsetup/service_state.go
@@ -2,6 +2,7 @@ package envsetup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,11 @@ import (
 	"cs2-highlight-tool-v2/internal/download"
 	"cs2-highlight-tool-v2/internal/endpoints"
 	"cs2-highlight-tool-v2/internal/release"
+)
+
+var (
+	errDownloadCanceledByUser = errors.New(downloadCanceledMessage)
+	errDownloadRaceFinished   = errors.New("下载竞速已结束")
 )
 
 func (s *Service) ensureReleaseSnapshot(source DownloadSource, force bool) error {
@@ -285,9 +291,9 @@ func (s *Service) updatePhaseByReadiness() {
 	s.emitState()
 }
 
-func (s *Service) downloadFile(componentID string, url string, targetPath string) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	active := &activeDownloadCancel{cancel: cancel}
+func (s *Service) beginDownloadGroup(componentID string) (*activeDownloadCancel, context.Context, context.CancelCauseFunc) {
+	ctx, cancelCause := context.WithCancelCause(context.Background())
+	active := &activeDownloadCancel{cancel: func() { cancelCause(errDownloadCanceledByUser) }}
 
 	s.cancelMu.Lock()
 	if oldCancel, exists := s.cancelMap[componentID]; exists {
@@ -297,6 +303,19 @@ func (s *Service) downloadFile(componentID string, url string, targetPath string
 	}
 	s.cancelMap[componentID] = active
 	s.cancelMu.Unlock()
+	return active, ctx, cancelCause
+}
+
+func (s *Service) endDownloadGroup(componentID string, active *activeDownloadCancel) {
+	s.cancelMu.Lock()
+	if s.cancelMap[componentID] == active {
+		delete(s.cancelMap, componentID)
+	}
+	s.cancelMu.Unlock()
+}
+
+func (s *Service) downloadFile(componentID string, url string, targetPath string) error {
+	active, ctx, cancelCause := s.beginDownloadGroup(componentID)
 
 	started := s.logStepStart(componentID, "download", "download_asset", string(s.currentSource()), 0, map[string]string{
 		"url":    url,
@@ -306,12 +325,8 @@ func (s *Service) downloadFile(componentID string, url string, targetPath string
 		s.emitProgress(componentID, active, percent, indeterminate)
 	})
 
-	s.cancelMu.Lock()
-	if s.cancelMap[componentID] == active {
-		delete(s.cancelMap, componentID)
-	}
-	s.cancelMu.Unlock()
-	cancel()
+	s.endDownloadGroup(componentID, active)
+	cancelCause(nil)
 
 	if err != nil {
 		s.logStepFail(componentID, "download", "download_asset", string(s.currentSource()), 0, started, err, map[string]string{

--- a/internal/envsetup/service_state.go
+++ b/internal/envsetup/service_state.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	errDownloadCanceledByUser = errors.New(downloadCanceledMessage)
-	errDownloadRaceFinished   = errors.New("下载竞速已结束")
+	errDownloadFinished       = errors.New("下载已结束")
 )
 
 func (s *Service) ensureReleaseSnapshot(source DownloadSource, force bool) error {
@@ -293,7 +293,10 @@ func (s *Service) updatePhaseByReadiness() {
 
 func (s *Service) beginDownloadGroup(componentID string) (*activeDownloadCancel, context.Context, context.CancelCauseFunc) {
 	ctx, cancelCause := context.WithCancelCause(context.Background())
-	active := &activeDownloadCancel{cancel: func() { cancelCause(errDownloadCanceledByUser) }}
+	active := &activeDownloadCancel{
+		cancel: func() { cancelCause(errDownloadCanceledByUser) },
+		ctx:    ctx,
+	}
 
 	s.cancelMu.Lock()
 	if oldCancel, exists := s.cancelMap[componentID]; exists {
@@ -304,6 +307,13 @@ func (s *Service) beginDownloadGroup(componentID string) (*activeDownloadCancel,
 	s.cancelMap[componentID] = active
 	s.cancelMu.Unlock()
 	return active, ctx, cancelCause
+}
+
+func (a *activeDownloadCancel) canceledByUser() bool {
+	if a == nil || a.ctx == nil {
+		return false
+	}
+	return errors.Is(context.Cause(a.ctx), errDownloadCanceledByUser)
 }
 
 func (s *Service) endDownloadGroup(componentID string, active *activeDownloadCancel) {
@@ -325,8 +335,13 @@ func (s *Service) downloadFile(componentID string, url string, targetPath string
 		s.emitProgress(componentID, active, percent, indeterminate)
 	})
 
+	// 统一提交：先结束取消仲裁，再移除取消注册。
+	// 如果用户取消先于提交发生，即使文件已经下载完成，也以取消为准。
+	cancelCause(errDownloadFinished)
+	if isUserCancelCause(ctx) {
+		err = download.ErrCanceled
+	}
 	s.endDownloadGroup(componentID, active)
-	cancelCause(nil)
 
 	if err != nil {
 		s.logStepFail(componentID, "download", "download_asset", string(s.currentSource()), 0, started, err, map[string]string{


### PR DESCRIPTION
## 概述

统一更新源下，CN / GeoIP 失败或为空时组件包会同时拿到 `mirror_url` 和 `url` 两条链路。原实现按固定顺序串行下载，只有硬失败才回退；当首选链路“很慢但不断流”时会一直卡住。本 PR 改为双路并行竞速：

- 多候选（`mirror_url` + `url`）同时下载，第一个成功完成的链路胜出，其余立即取消并清理临时文件；
- 单候选（非 CN 仅 `github_url`）保持原有顺序下载逻辑；
- 竞速胜者安装失败时，自动回退到剩余候选重新下载安装；
- 竞速期间只上报进度最高链路的进度，避免进度条来回跳动。

同时修复审查发现的取消时序问题：

- 竞速结果统一仲裁：接收结果前后都检查用户取消，成功结果已入队也不能覆盖先发生的用户取消；
- 顺序下载路径增加统一提交点，下载完成/失败后迟到的取消请求不再把步骤改成 `failed`，避免界面先显示“已取消”又继续安装；
- `CancelStartupDownload` 只在取消真正生效时标记失败。

## 验证

- `go build ./...`
- `go vet ./internal/envsetup/`
- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/envsetup/`
- `git diff --check`

全部通过。Windows 真实下载交互（Wails 环境）仍需实机验证。

## 备注

CN / GeoIP 失败或为空时会同时占用 `mirror_url` 与 `url` 两条链路带宽，这是方案一（并行竞速）的预期取舍；实际自动下载的组件主要是 HLAE 与 plugin，软件自更新仅检查版本并打开浏览器下载。
