### PR TITLE
fix(app): protect workspace lifecycle and isolate background tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ CS2 Demo 导入、片段选择、自动录制与后期拼接的 Windows 桌面�
 - Windows 从 `HKCU\Software\CS2HighlightTool` 的 `DataDir` 读取工作目录；未配置或目录不可用时进入 `workspace_init`。选择父目录时自动追加 `cs2HighLightTool`；目录校验由 `internal/appdata/validate.go` 负责。
 - `<dataDir>` 是已选工作目录，配置、组件、Demo、输出、临时文件和日志均以此为根；不可再假设 Windows 固定使用 `%LOCALAPPDATA%/CS2 Highlight Tool`。非 Windows 开发回退见 `fallbackDataDirForDev`。
 - `<exeDir>` 与 `<dataDir>` 必须区分：前者定位程序和自更新替换目标。`ResetWorkspace` 会删除当前整个工作目录并清除注册表记录，不等同于清理 Demo 或 outputs。
+- `internal/app/workspace_session.go` 的私有工作目录实例固定 root、generation、envsetup service 与生命周期 context；后台任务须先登记，Reset/Shutdown 先关闭准入并按既有制作/文件占用规则取消、等待或拒绝，旧实例不得在新工作目录提交后写文件或发射启动事件。
 - `GetStartupState`、`RunStartupChecks`、`RetryStartupComponent`、`ReinstallStartupComponent`、`CancelStartupDownload`、`OpenManualDownload`、`ImportManualDownload`、`PickCS2Path`、`EnterMainApp`、`OpenExternalURL`、`ExportStartupLogs` 的入口为 `internal/app/app_startup.go`。
 - 状态源为 `GetStartupState` 和 `startup_state_changed`，模型见 `internal/envsetup/state.go`。`mode` 为 `workspace_init|startup|main`；`phase` 为 `detecting_source|waiting_source|running_tasks|ready`；二者不可混用。
 - 组件 ID：`hlae`、`plugin`、`ffmpeg`、`cs2`。组件/启动状态：`pending`、`checking`、`downloading`、`installing`、`ready`、`warning`、`failed`、`needs_action`。

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -23,6 +23,7 @@
 ## 并发、进程与收尾
 
 - `Service.state`、`Service.logs`、`Service.config` 遵循现有 `mu/configMu` 锁策略；应用 service 的访问遵循 `serviceMu`。
+- `app/workspace_session.go` 的私有 `workspaceSession` 持有不可变 root/generation/service 与生命周期 context；任务须在启动前登记。切换/退出先关闭准入，再取消并等待，不得在 service/state 锁内等待、做 I/O 或发射事件。`envsetup.Service` 的 `BindLifecycleContext`、`CloseIfIdle`、`Stop` 仅由 App 的 session 生命周期调用，旧实例关闭后不得重新接收任务。
 - 避免锁内执行阻塞 I/O、网络或 runtime 事件发射，不引入锁顺序反转。启动状态更新后通过 `emitState()` 通知前端；制作事件复用现有队列。
 - `GetWorkActivity` 的前端禁用策略不代替后端互斥；文件读写/导出/清理复用现有文件使用权机制。
 - 制作生命周期遵循根文件“制作、剪辑与清理”：活跃会话禁止重复生成，失败收尾保留重试所需状态；未确认进程退出、环境恢复前不得提前释放备份和占用。

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,6 +26,10 @@ type App struct {
 	produceW *producews.Service
 
 	serviceMu sync.Mutex
+	// workspace is the immutable identity used by new operations. service and
+	// dataDir remain mirrors for compatibility with existing App consumers.
+	workspace           *workspaceSession
+	workspaceGeneration uint64
 	// configMu serializes App-level read-modify-write operations on config.json.
 	// It intentionally does not cover external work; callers load or persist
 	// through the helpers below and release the lock before doing other I/O.
@@ -110,9 +114,11 @@ func (a *App) initWorkspaceLocked() {
 			_ = appdata.DeleteDataDirFromRegistry()
 			return
 		}
-		a.dataDir = stored
-		a.seedFirstInstallChangelog()
-		a.service = envsetup.NewWithDataDir(a.exeDir, stored, a.version)
+		svc := envsetup.NewWithDataDir(a.exeDir, stored, a.version)
+		a.serviceMu.Lock()
+		a.installWorkspaceLocked(stored, svc)
+		a.serviceMu.Unlock()
+		a.seedFirstInstallChangelogAt(stored, a.version)
 		return
 	}
 
@@ -120,9 +126,11 @@ func (a *App) initWorkspaceLocked() {
 	fallback := fallbackDataDirForDev(a.exeDir)
 	if fallback != "" {
 		_ = os.MkdirAll(fallback, 0o755)
-		a.dataDir = fallback
-		a.seedFirstInstallChangelog()
-		a.service = envsetup.NewWithDataDir(a.exeDir, fallback, a.version)
+		svc := envsetup.NewWithDataDir(a.exeDir, fallback, a.version)
+		a.serviceMu.Lock()
+		a.installWorkspaceLocked(fallback, svc)
+		a.serviceMu.Unlock()
+		a.seedFirstInstallChangelogAt(fallback, a.version)
 	}
 }
 
@@ -201,13 +209,17 @@ func (a *App) Startup(ctx context.Context) {
 		wruntime.LogError(ctx, fmt.Sprintf("start produce websocket server failed: %v", err))
 	}
 
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
-
-	if svc != nil {
-		svc.Startup(ctx)
-		return
+	a.ensureWorkspaceSession()
+	releaseWorkspace, _, workspaceErr := a.beginManagedWorkspaceUse()
+	if workspaceErr == nil {
+		defer releaseWorkspace()
+		svc := a.workspaceSnapshot().service
+		if svc != nil {
+			svc.Startup(ctx)
+			return
+		}
+	} else if snapshot := a.workspaceSnapshot(); snapshot.service != nil && a.ctx != nil {
+		wruntime.LogError(a.ctx, fmt.Sprintf("启动工作目录服务失败: %v", workspaceErr))
 	}
 
 	// service 为空：未初始化工作目录，发出 workspace_init mode 状态。
@@ -215,10 +227,13 @@ func (a *App) Startup(ctx context.Context) {
 }
 
 func (a *App) Shutdown(ctx context.Context) {
-	// Serialize shutdown with the launch pipeline so environment preparation,
-	// runtime installation, and teardown cannot interleave while the app exits.
-	a.produceLaunchMu.Lock()
-	defer a.produceLaunchMu.Unlock()
+	// Serialize shutdown with the launch pipeline and stop admitting new managed
+	// workspace work. Existing file users are allowed to finish; the session
+	// close below cancels/waits for app-owned background tasks.
+	releaseShutdown := a.beginWorkspaceShutdown()
+	if releaseShutdown != nil {
+		defer releaseShutdown()
+	}
 
 	// Never restore game files while an owned CS2 process may still be alive.
 	// A failed stop retains the runtime and its backups for next-start recovery.
@@ -228,6 +243,11 @@ func (a *App) Shutdown(ctx context.Context) {
 		}
 	} else if err := a.forceRestoreProduceEnvironmentForProduce(); err != nil {
 		wruntime.LogError(ctx, fmt.Sprintf("restore produce environment failed: %v", err))
+	}
+	if session := a.workspaceSnapshot().session; session != nil {
+		if err := session.close(ctx); err != nil && ctx != nil {
+			wruntime.LogError(ctx, fmt.Sprintf("stop workspace session failed: %v", err))
+		}
 	}
 	if err := a.produceW.Stop(); err != nil {
 		wruntime.LogError(ctx, fmt.Sprintf("stop produce websocket server failed: %v", err))
@@ -247,19 +267,20 @@ func (a *App) dataRoot() string {
 	if a == nil {
 		return ""
 	}
-	a.serviceMu.Lock()
-	dataDir := a.dataDir
-	exeDir := a.exeDir
-	pending := a.workspaceResetPendingPath != "" || a.workspaceResetRegistryPending
-	resetCompleted := a.workspaceResetCompleted
-	a.serviceMu.Unlock()
-	if dataDir != "" {
-		return dataDir
+	snapshot := a.workspaceSnapshot()
+	if snapshot.session != nil {
+		if snapshot.session.isClosed() {
+			return ""
+		}
+		return snapshot.root
 	}
-	if pending || resetCompleted {
+	if snapshot.root != "" {
+		return snapshot.root
+	}
+	if snapshot.pendingReset || snapshot.resetComplete {
 		return ""
 	}
-	return exeDir
+	return snapshot.exeDir
 }
 
 func (a *App) dataPath(elem ...string) string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -40,9 +40,19 @@ type App struct {
 	// never interleave and corrupt each other's environment or take state.
 	produceLaunchMu sync.Mutex
 
-	managedFilesMu       sync.Mutex
+	managedFilesMu sync.Mutex
+	// managedFileUsers counts every operation that may touch the managed
+	// workspace, including startup tasks registered by the App. The name is
+	// retained for compatibility with the existing file-use tests.
 	managedFileUsers     int
 	managedFilesClearing bool
+
+	// A failed reset detaches the old service so it cannot write into a
+	// partially removed directory. Keep enough state to make ResetWorkspace
+	// retryable without allowing a new workspace to be installed in between.
+	workspaceResetPendingPath     string
+	workspaceResetRegistryPending bool
+	workspaceResetCompleted       bool
 
 	// produceEnvEpoch is the monotonically increasing produce-environment
 	// generation counter (see beginProduceEnvironmentPrep). Guarded by
@@ -121,10 +131,21 @@ func (a *App) initWorkspaceLocked() {
 // 必须在 dataDir 已设置、任何 LoadOrCreate 之前调用。失败仅吞噬：下一次
 // LoadOrCreate 会以同等原因再次失败并自然把错误带回前端。
 func (a *App) seedFirstInstallChangelog() {
-	if a.dataDir == "" || a.version == "" {
+	if a == nil {
 		return
 	}
-	_, _ = config.EnsureFirstInstallChangelogSeed(a.configPath(), a.dataDir, a.version)
+	a.serviceMu.Lock()
+	dataDir := a.dataDir
+	version := a.version
+	a.serviceMu.Unlock()
+	a.seedFirstInstallChangelogAt(dataDir, version)
+}
+
+func (a *App) seedFirstInstallChangelogAt(dataDir string, version string) {
+	if a == nil || dataDir == "" || version == "" {
+		return
+	}
+	_, _ = config.EnsureFirstInstallChangelogSeed(filepath.Join(dataDir, "config.json"), dataDir, version)
 }
 
 // isUsableDataDir 用于"已初始化"分支：目录存在 + 字符白名单 + 非磁盘根 + 长度合规。
@@ -223,13 +244,22 @@ func resolveExecutableDir() string {
 }
 
 func (a *App) dataRoot() string {
-	if a != nil && a.dataDir != "" {
-		return a.dataDir
+	if a == nil {
+		return ""
 	}
-	if a != nil {
-		return a.exeDir
+	a.serviceMu.Lock()
+	dataDir := a.dataDir
+	exeDir := a.exeDir
+	pending := a.workspaceResetPendingPath != "" || a.workspaceResetRegistryPending
+	resetCompleted := a.workspaceResetCompleted
+	a.serviceMu.Unlock()
+	if dataDir != "" {
+		return dataDir
 	}
-	return ""
+	if pending || resetCompleted {
+		return ""
+	}
+	return exeDir
 }
 
 func (a *App) dataPath(elem ...string) string {
@@ -242,17 +272,29 @@ func (a *App) configPath() string {
 }
 
 func (a *App) loadConfig() (*config.Config, error) {
+	release, dataDir, err := a.beginManagedWorkspaceUse()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	a.configMu.Lock()
 	defer a.configMu.Unlock()
-	return config.LoadOrCreate(a.configPath(), a.dataRoot())
+	return config.LoadOrCreate(filepath.Join(dataDir, "config.json"), dataDir)
 }
 
 func (a *App) updateConfig(mutate func(*config.Config) error) (*config.Config, error) {
+	release, dataDir, err := a.beginManagedWorkspaceUse()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	a.configMu.Lock()
 	defer a.configMu.Unlock()
 
-	path := a.configPath()
-	cfg, err := config.LoadOrCreate(path, a.dataRoot())
+	path := filepath.Join(dataDir, "config.json")
+	cfg, err := config.LoadOrCreate(path, dataDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/app_fivee.go
+++ b/internal/app/app_fivee.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"cs2-highlight-tool-v2/internal/config"
@@ -53,7 +54,7 @@ func (a *App) saveFiveEPlayerName(playerName string) error {
 }
 
 func (a *App) ImportFiveEMatch(matchID string) ([]string, error) {
-	releaseFiles, fileErr := a.beginManagedFileUse()
+	releaseFiles, dataDir, fileErr := a.beginManagedWorkspaceUse()
 	if fileErr != nil {
 		return nil, fileErr
 	}
@@ -63,7 +64,7 @@ func (a *App) ImportFiveEMatch(matchID string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	cacheRoot := a.dataPath("demo", "5e", downloadMatchID)
+	cacheRoot := filepath.Join(dataDir, "demo", "5e", downloadMatchID)
 	progressID := fivee.ProgressComponentID(downloadMatchID)
 
 	stablePath, err := fivee.ImportDemo(downloadMatchID, cacheRoot, func(active bool, percent float64, indeterminate bool) {
@@ -72,12 +73,15 @@ func (a *App) ImportFiveEMatch(matchID string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	a.cleanupLegacyRawDemoCopy(stablePath)
+	a.cleanupLegacyRawDemoCopyAt(stablePath, dataDir)
 	return []string{stablePath}, nil
 }
 
 func (a *App) emitFiveEDownloadProgress(componentID string, active bool, percent float64, indeterminate bool) {
 	if a == nil || a.ctx == nil || strings.TrimSpace(componentID) == "" {
+		return
+	}
+	if session := a.workspaceSnapshot().session; session != nil && session.isClosed() {
 		return
 	}
 	wailsruntime.EventsEmit(a.ctx, "download_progress", envsetup.ProgressMessage{

--- a/internal/app/app_startup.go
+++ b/internal/app/app_startup.go
@@ -12,9 +12,13 @@ func workspaceNotInitializedErr() error {
 }
 
 func (a *App) GetStartupState() envsetup.StartupState {
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
+	release, _, err := a.beginManagedWorkspaceUse()
+	if err != nil {
+		return envsetup.StartupState{Mode: envsetup.ModeWorkspaceInit}
+	}
+	defer release()
+	snapshot := a.workspaceSnapshot()
+	svc := snapshot.service
 	if svc == nil {
 		return envsetup.StartupState{Mode: envsetup.ModeWorkspaceInit}
 	}
@@ -58,32 +62,29 @@ func (a *App) RetryStartupComponent(componentID string) envsetup.StartupState {
 }
 
 func (a *App) CancelStartupDownload(componentID string) envsetup.StartupState {
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
-	if svc == nil {
+	release, svc, ok := a.beginStartupTask()
+	if !ok {
 		return envsetup.StartupState{Mode: envsetup.ModeWorkspaceInit}
 	}
+	defer release()
 	return svc.CancelStartupDownload(componentID)
 }
 
 func (a *App) OpenManualDownload(componentID string) error {
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
-	if svc == nil {
+	release, svc, ok := a.beginStartupTask()
+	if !ok {
 		return workspaceNotInitializedErr()
 	}
+	defer release()
 	return svc.OpenManualDownload(componentID)
 }
 
 func (a *App) OpenExternalURL(rawURL string) error {
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
-	if svc == nil {
+	release, svc, ok := a.beginStartupTask()
+	if !ok {
 		return workspaceNotInitializedErr()
 	}
+	defer release()
 	return svc.OpenExternalURL(rawURL)
 }
 
@@ -106,12 +107,11 @@ func (a *App) PickCS2Path() envsetup.StartupState {
 }
 
 func (a *App) EnterMainApp() error {
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
-	if svc == nil {
+	release, svc, ok := a.beginStartupTask()
+	if !ok {
 		return workspaceNotInitializedErr()
 	}
+	defer release()
 	return svc.EnterMainApp()
 }
 

--- a/internal/app/app_startup.go
+++ b/internal/app/app_startup.go
@@ -21,23 +21,39 @@ func (a *App) GetStartupState() envsetup.StartupState {
 	return svc.GetStartupState()
 }
 
-func (a *App) RunStartupChecks() envsetup.StartupState {
+// beginStartupTask snapshots the current service only after reserving the
+// workspace. ResetWorkspace therefore cannot detach the service between the
+// pointer read and the operation that uses it.
+func (a *App) beginStartupTask() (func(), *envsetup.Service, bool) {
+	release, _, err := a.beginManagedWorkspaceUse()
+	if err != nil {
+		return nil, nil, false
+	}
 	a.serviceMu.Lock()
 	svc := a.service
 	a.serviceMu.Unlock()
 	if svc == nil {
+		release()
+		return nil, nil, false
+	}
+	return release, svc, true
+}
+
+func (a *App) RunStartupChecks() envsetup.StartupState {
+	release, svc, ok := a.beginStartupTask()
+	if !ok {
 		return envsetup.StartupState{Mode: envsetup.ModeWorkspaceInit}
 	}
+	defer release()
 	return svc.RunStartupChecks()
 }
 
 func (a *App) RetryStartupComponent(componentID string) envsetup.StartupState {
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
-	if svc == nil {
+	release, svc, ok := a.beginStartupTask()
+	if !ok {
 		return envsetup.StartupState{Mode: envsetup.ModeWorkspaceInit}
 	}
+	defer release()
 	return svc.RetryStartupComponent(componentID)
 }
 
@@ -72,22 +88,20 @@ func (a *App) OpenExternalURL(rawURL string) error {
 }
 
 func (a *App) ImportManualDownload(componentID string) envsetup.StartupState {
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
-	if svc == nil {
+	release, svc, ok := a.beginStartupTask()
+	if !ok {
 		return envsetup.StartupState{Mode: envsetup.ModeWorkspaceInit}
 	}
+	defer release()
 	return svc.ImportManualDownload(componentID)
 }
 
 func (a *App) PickCS2Path() envsetup.StartupState {
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
-	if svc == nil {
+	release, svc, ok := a.beginStartupTask()
+	if !ok {
 		return envsetup.StartupState{Mode: envsetup.ModeWorkspaceInit}
 	}
+	defer release()
 	return svc.PickCS2Path()
 }
 
@@ -102,21 +116,19 @@ func (a *App) EnterMainApp() error {
 }
 
 func (a *App) ReinstallStartupComponent(componentID string) (envsetup.StartupState, error) {
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
-	if svc == nil {
+	release, svc, ok := a.beginStartupTask()
+	if !ok {
 		return envsetup.StartupState{Mode: envsetup.ModeWorkspaceInit}, workspaceNotInitializedErr()
 	}
+	defer release()
 	return svc.ReinstallStartupComponent(componentID)
 }
 
 func (a *App) ExportStartupLogs() (string, error) {
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
-	if svc == nil {
+	release, svc, ok := a.beginStartupTask()
+	if !ok {
 		return "", workspaceNotInitializedErr()
 	}
+	defer release()
 	return svc.ExportStartupLogs()
 }

--- a/internal/app/app_wanmei.go
+++ b/internal/app/app_wanmei.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"path/filepath"
 	"strings"
 
 	"cs2-highlight-tool-v2/internal/envsetup"
@@ -14,7 +15,7 @@ func (a *App) ListWanmeiRecentMatches(page int) (*wanmei.WanmeiMatchListResult, 
 }
 
 func (a *App) ImportWanmeiMatch(matchID string) ([]string, error) {
-	releaseFiles, fileErr := a.beginManagedFileUse()
+	releaseFiles, dataDir, fileErr := a.beginManagedWorkspaceUse()
 	if fileErr != nil {
 		return nil, fileErr
 	}
@@ -24,7 +25,7 @@ func (a *App) ImportWanmeiMatch(matchID string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	cacheRoot := a.dataPath("demo", "wanmei", downloadMatchID)
+	cacheRoot := filepath.Join(dataDir, "demo", "wanmei", downloadMatchID)
 	progressID := wanmei.ProgressComponentID(downloadMatchID)
 
 	stablePath, err := wanmei.ImportDemo(downloadMatchID, cacheRoot, func(active bool, percent float64, indeterminate bool) {
@@ -33,12 +34,15 @@ func (a *App) ImportWanmeiMatch(matchID string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	a.cleanupLegacyRawDemoCopy(stablePath)
+	a.cleanupLegacyRawDemoCopyAt(stablePath, dataDir)
 	return []string{stablePath}, nil
 }
 
 func (a *App) emitWanmeiDownloadProgress(componentID string, active bool, percent float64, indeterminate bool) {
 	if a == nil || a.ctx == nil || strings.TrimSpace(componentID) == "" {
+		return
+	}
+	if session := a.workspaceSnapshot().session; session != nil && session.isClosed() {
 		return
 	}
 	wailsruntime.EventsEmit(a.ctx, "download_progress", envsetup.ProgressMessage{

--- a/internal/app/app_workspace.go
+++ b/internal/app/app_workspace.go
@@ -50,11 +50,10 @@ type WorkspaceState struct {
 
 // GetWorkspaceState 返回当前工作目录初始化状态。
 func (a *App) GetWorkspaceState() WorkspaceState {
-	a.serviceMu.Lock()
-	defer a.serviceMu.Unlock()
+	snapshot := a.workspaceSnapshot()
 	ws := WorkspaceState{
-		Initialized: a.service != nil,
-		DataDir:     a.dataDir,
+		Initialized: snapshot.service != nil && snapshot.root != "",
+		DataDir:     snapshot.root,
 	}
 	return ws
 }
@@ -95,10 +94,9 @@ func (a *App) SetWorkspaceDir(path string) error {
 	}
 	defer releaseTransition()
 
-	a.serviceMu.Lock()
-	pendingReset := a.workspaceResetPendingPath != "" || a.workspaceResetRegistryPending
-	initialized := a.service != nil || a.dataDir != ""
-	a.serviceMu.Unlock()
+	snapshot := a.workspaceSnapshot()
+	pendingReset := snapshot.pendingReset
+	initialized := snapshot.service != nil || snapshot.root != ""
 	if pendingReset {
 		return fmt.Errorf("工作目录重置尚未完成，请先重试重置")
 	}
@@ -118,34 +116,33 @@ func (a *App) SetWorkspaceDir(path string) error {
 		}
 	}
 
+	// 构造 service 并启动。先提交不可变 workspace session，再登记所有
+	// 即将启动的后台任务；整个过程仍在生命周期排他资格内。
+	svc := envsetup.NewWithDataDir(a.exeDir, path, a.version)
+	a.serviceMu.Lock()
+	session := a.installWorkspaceLocked(path, svc)
+	a.serviceMu.Unlock()
+	a.seedFirstInstallChangelogAt(path, a.version)
+	a.configureProduceDiagnostics(path)
+
 	// 后台清理 legacy 数据，失败仅 log，不阻塞主流程。
 	exeDir := a.exeDir
-	legacyRelease := a.reserveManagedWorkspaceTask()
+	legacyRelease := a.reserveManagedWorkspaceTaskForSession(session)
 	go func() {
 		defer legacyRelease()
-		if err := appdata.CleanupLegacyData(exeDir); err != nil {
+		if err := appdata.CleanupLegacyData(exeDir); err != nil && !session.isClosed() {
 			if a.ctx != nil {
 				wruntime.LogWarning(a.ctx, fmt.Sprintf("cleanup legacy app data failed: %v", err))
 			}
 		}
 	}()
 
-	// 构造 service 并启动
-	a.serviceMu.Lock()
-	a.dataDir = path
-	a.workspaceResetCompleted = false
-	a.service = envsetup.NewWithDataDir(a.exeDir, path, a.version)
-	svc := a.service
-	a.serviceMu.Unlock()
-	a.seedFirstInstallChangelogAt(path, a.version)
-	a.configureProduceDiagnostics(path)
-
 	if a.ctx != nil {
 		svc.Startup(a.ctx)
 	}
 
 	// 触发启动检查（异步）
-	startupRelease := a.reserveManagedWorkspaceTask()
+	startupRelease := a.reserveManagedWorkspaceTaskForSession(session)
 	go func() {
 		defer startupRelease()
 		svc.RunStartupChecks()
@@ -166,8 +163,13 @@ func (a *App) ResetWorkspace() error {
 	configuredDataDir := a.dataDir
 	pendingDataDir := a.workspaceResetPendingPath
 	service := a.service
+	session := a.workspace
 	registryPending := a.workspaceResetRegistryPending
 	a.serviceMu.Unlock()
+	if session != nil {
+		configuredDataDir = session.root
+		service = session.service
+	}
 	if configuredDataDir == "" && pendingDataDir == "" && service == nil && !registryPending {
 		// Already uninitialized: keep reset idempotent without repeating
 		// registry/diagnostics side effects.
@@ -180,6 +182,12 @@ func (a *App) ResetWorkspace() error {
 	}
 
 	if service != nil && service.HasActiveTasks() {
+		return fmt.Errorf("启动检查或后台组件任务仍在运行，请完成后再试")
+	}
+	if session != nil && !session.closeIfIdle() {
+		return fmt.Errorf("启动检查或后台组件任务仍在运行，请完成后再试")
+	}
+	if session == nil && service != nil && !service.CloseIfIdle() {
 		return fmt.Errorf("启动检查或后台组件任务仍在运行，请完成后再试")
 	}
 
@@ -202,11 +210,14 @@ func (a *App) ResetWorkspace() error {
 	a.serviceMu.Lock()
 	a.service = nil
 	a.dataDir = ""
+	a.workspace = nil
+	a.workspaceGeneration++
 	a.workspaceResetPendingPath = ""
 	a.workspaceResetRegistryPending = false
 	a.workspaceResetCompleted = true
 	a.serviceMu.Unlock()
 	a.configureProduceDiagnostics(a.exeDir)
+	a.clearProduceWorkspaceState()
 
 	a.emitWorkspaceInitState()
 	return nil
@@ -220,8 +231,10 @@ func (a *App) detachWorkspaceForReset(dataDir string) {
 	a.serviceMu.Lock()
 	a.service = nil
 	a.dataDir = ""
+	a.workspace = nil
+	a.workspaceGeneration++
 	a.workspaceResetPendingPath = dataDir
-	a.workspaceResetRegistryPending = true
+	a.workspaceResetRegistryPending = runtime.GOOS == "windows"
 	a.serviceMu.Unlock()
 	a.configureProduceDiagnostics(a.exeDir)
 }

--- a/internal/app/app_workspace.go
+++ b/internal/app/app_workspace.go
@@ -15,6 +15,14 @@ import (
 // appSubDir 是应用在用户选择的父目录下自动创建的子目录名。
 const appSubDir = "cs2HighLightTool"
 
+// Keep destructive/external operations replaceable in focused tests. The
+// production implementations remain the appdata/os functions below.
+var (
+	writeDataDirToRegistry    = appdata.WriteDataDirToRegistry
+	deleteDataDirFromRegistry = appdata.DeleteDataDirFromRegistry
+	removeWorkspaceDir        = os.RemoveAll
+)
+
 // appendAppSubdir 在 parent 末尾追加 appSubDir。
 // 若路径末段已是 appSubDir，直接返回原值（幂等）。
 func appendAppSubdir(parent string) string {
@@ -81,6 +89,23 @@ func (a *App) ValidateWorkspaceDir(path string) WorkspaceValidateResult {
 // SetWorkspaceDir 接受用户最终选择，写注册表，
 // 清理 legacy 数据，构造 service 并触发 RunStartupChecks。
 func (a *App) SetWorkspaceDir(path string) error {
+	releaseTransition, err := a.beginWorkspaceTransition()
+	if err != nil {
+		return err
+	}
+	defer releaseTransition()
+
+	a.serviceMu.Lock()
+	pendingReset := a.workspaceResetPendingPath != "" || a.workspaceResetRegistryPending
+	initialized := a.service != nil || a.dataDir != ""
+	a.serviceMu.Unlock()
+	if pendingReset {
+		return fmt.Errorf("工作目录重置尚未完成，请先重试重置")
+	}
+	if initialized {
+		return fmt.Errorf("工作目录已初始化，不能在运行中切换；请先重置工作目录")
+	}
+
 	if err := appdata.ValidateDataDir(path); err != nil {
 		return err
 	}
@@ -88,14 +113,16 @@ func (a *App) SetWorkspaceDir(path string) error {
 	// Windows 写注册表。非 Windows 平台略过（registry_other.go 返回 unsupported），
 	// 视为本地开发兜底场景，依然允许设置。
 	if runtime.GOOS == "windows" {
-		if err := appdata.WriteDataDirToRegistry(path); err != nil {
+		if err := writeDataDirToRegistry(path); err != nil {
 			return fmt.Errorf("写入注册表失败: %w", err)
 		}
 	}
 
 	// 后台清理 legacy 数据，失败仅 log，不阻塞主流程。
 	exeDir := a.exeDir
+	legacyRelease := a.reserveManagedWorkspaceTask()
 	go func() {
+		defer legacyRelease()
 		if err := appdata.CleanupLegacyData(exeDir); err != nil {
 			if a.ctx != nil {
 				wruntime.LogWarning(a.ctx, fmt.Sprintf("cleanup legacy app data failed: %v", err))
@@ -106,10 +133,11 @@ func (a *App) SetWorkspaceDir(path string) error {
 	// 构造 service 并启动
 	a.serviceMu.Lock()
 	a.dataDir = path
-	a.seedFirstInstallChangelog()
+	a.workspaceResetCompleted = false
 	a.service = envsetup.NewWithDataDir(a.exeDir, path, a.version)
 	svc := a.service
 	a.serviceMu.Unlock()
+	a.seedFirstInstallChangelogAt(path, a.version)
 	a.configureProduceDiagnostics(path)
 
 	if a.ctx != nil {
@@ -117,7 +145,9 @@ func (a *App) SetWorkspaceDir(path string) error {
 	}
 
 	// 触发启动检查（异步）
+	startupRelease := a.reserveManagedWorkspaceTask()
 	go func() {
+		defer startupRelease()
 		svc.RunStartupChecks()
 	}()
 	return nil
@@ -126,22 +156,45 @@ func (a *App) SetWorkspaceDir(path string) error {
 // ResetWorkspace 删除当前 DataDir + 清注册表 + 重置 service。
 // 调用后前端会收到 mode=workspace_init 状态。
 func (a *App) ResetWorkspace() error {
-	a.serviceMu.Lock()
-	dataDir := a.dataDir
-	a.serviceMu.Unlock()
+	releaseTransition, err := a.beginWorkspaceTransition()
+	if err != nil {
+		return err
+	}
+	defer releaseTransition()
 
-	if dataDir == "" {
-		// 已经未初始化，幂等
+	a.serviceMu.Lock()
+	configuredDataDir := a.dataDir
+	pendingDataDir := a.workspaceResetPendingPath
+	service := a.service
+	registryPending := a.workspaceResetRegistryPending
+	a.serviceMu.Unlock()
+	if configuredDataDir == "" && pendingDataDir == "" && service == nil && !registryPending {
+		// Already uninitialized: keep reset idempotent without repeating
+		// registry/diagnostics side effects.
 		a.emitWorkspaceInitState()
 		return nil
 	}
+	dataDir := configuredDataDir
+	if dataDir == "" {
+		dataDir = pendingDataDir
+	}
 
-	if err := os.RemoveAll(dataDir); err != nil {
-		return fmt.Errorf("删除工作目录失败: %w", err)
+	if service != nil && service.HasActiveTasks() {
+		return fmt.Errorf("启动检查或后台组件任务仍在运行，请完成后再试")
+	}
+
+	if dataDir != "" {
+		if err := removeWorkspaceDir(dataDir); err != nil {
+			a.detachWorkspaceForReset(dataDir)
+			a.emitWorkspaceInitState()
+			return fmt.Errorf("删除工作目录失败: %w", err)
+		}
 	}
 
 	if runtime.GOOS == "windows" {
-		if err := appdata.DeleteDataDirFromRegistry(); err != nil {
+		if err := deleteDataDirFromRegistry(); err != nil {
+			a.detachWorkspaceForReset(dataDir)
+			a.emitWorkspaceInitState()
 			return fmt.Errorf("清除注册表失败: %w", err)
 		}
 	}
@@ -149,11 +202,28 @@ func (a *App) ResetWorkspace() error {
 	a.serviceMu.Lock()
 	a.service = nil
 	a.dataDir = ""
+	a.workspaceResetPendingPath = ""
+	a.workspaceResetRegistryPending = false
+	a.workspaceResetCompleted = true
 	a.serviceMu.Unlock()
 	a.configureProduceDiagnostics(a.exeDir)
 
 	a.emitWorkspaceInitState()
 	return nil
+}
+
+// detachWorkspaceForReset makes a failed/partial reset non-operational. The
+// old service is deliberately dropped before returning so it cannot recreate
+// files in the removed directory; the saved path and registry flag let a
+// later ResetWorkspace retry the remaining cleanup.
+func (a *App) detachWorkspaceForReset(dataDir string) {
+	a.serviceMu.Lock()
+	a.service = nil
+	a.dataDir = ""
+	a.workspaceResetPendingPath = dataDir
+	a.workspaceResetRegistryPending = true
+	a.serviceMu.Unlock()
+	a.configureProduceDiagnostics(a.exeDir)
 }
 
 // ExitApp 退出应用，供初始化 modal 的"退出"按钮调用。

--- a/internal/app/clip_settings.go
+++ b/internal/app/clip_settings.go
@@ -82,6 +82,12 @@ type ClipItemOverrides struct {
 }
 
 func (a *App) GetClipSettings() (*ClipSettings, error) {
+	release, fileErr := a.beginManagedFileUse()
+	if fileErr != nil {
+		return nil, fileErr
+	}
+	defer release()
+
 	cfg, err := a.loadConfig()
 	if err != nil {
 		return nil, err
@@ -117,6 +123,12 @@ func (a *App) GetClipSettings() (*ClipSettings, error) {
 }
 
 func (a *App) SaveClipSettings(input ClipSettings) (*ClipSettings, error) {
+	release, fileErr := a.beginManagedFileUse()
+	if fileErr != nil {
+		return nil, fileErr
+	}
+	defer release()
+
 	settings := normalizeClipSettings(input)
 	settings.RecordOutputDir = a.fixedRecordOutputDir()
 	updatedCfg, err := a.updateConfig(func(cfg *config.Config) error {
@@ -177,6 +189,12 @@ func (a *App) PickRecordOutputDir() (string, error) {
 }
 
 func (a *App) GetClipActionSettings() (*ClipActionSettings, error) {
+	release, fileErr := a.beginManagedFileUse()
+	if fileErr != nil {
+		return nil, fileErr
+	}
+	defer release()
+
 	cfg, err := a.loadConfig()
 	if err != nil {
 		return nil, err
@@ -192,6 +210,12 @@ func (a *App) GetClipActionSettings() (*ClipActionSettings, error) {
 }
 
 func (a *App) SaveClipActionSettings(input ClipActionSettings) (*ClipActionSettings, error) {
+	release, fileErr := a.beginManagedFileUse()
+	if fileErr != nil {
+		return nil, fileErr
+	}
+	defer release()
+
 	settings := normalizeClipActionSettings(input)
 	if _, err := a.updateConfig(func(cfg *config.Config) error {
 		config.SetClipActionSettings(cfg, config.ClipActionSettings{

--- a/internal/app/demo_import.go
+++ b/internal/app/demo_import.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (a *App) prepareRawDemoFiles(paths []string) ([]string, error) {
-	releaseFiles, fileErr := a.beginManagedFileUse()
+	releaseFiles, dataDir, fileErr := a.beginManagedWorkspaceUse()
 	if fileErr != nil {
 		return nil, fileErr
 	}
@@ -21,7 +21,7 @@ func (a *App) prepareRawDemoFiles(paths []string) ([]string, error) {
 	if len(paths) == 0 {
 		return nil, nil
 	}
-	rawRoot := a.dataPath("demo", "raw")
+	rawRoot := filepath.Join(dataDir, "demo", "raw")
 	if err := os.MkdirAll(rawRoot, 0755); err != nil {
 		return nil, fmt.Errorf("创建 demo raw 目录失败: %w", err)
 	}
@@ -108,14 +108,18 @@ func copyDemoToRaw(sourcePath string, rawRoot string) (string, error) {
 }
 
 func (a *App) cleanupLegacyRawDemoCopy(sourcePath string) {
-	if a == nil || strings.TrimSpace(sourcePath) == "" {
+	a.cleanupLegacyRawDemoCopyAt(sourcePath, a.dataRoot())
+}
+
+func (a *App) cleanupLegacyRawDemoCopyAt(sourcePath string, dataDir string) {
+	if a == nil || strings.TrimSpace(sourcePath) == "" || strings.TrimSpace(dataDir) == "" {
 		return
 	}
 	normalizedPath, err := normalizeSourcePath(sourcePath)
 	if err != nil {
 		return
 	}
-	rawRoot := a.dataPath("demo", "raw")
+	rawRoot := filepath.Join(strings.TrimSpace(dataDir), "demo", "raw")
 	legacyPath := filepath.Join(rawRoot, hashSourcePath(normalizedPath), filepath.Base(normalizedPath))
 	if samePath(normalizedPath, legacyPath) {
 		return

--- a/internal/app/edit_ffmpeg.go
+++ b/internal/app/edit_ffmpeg.go
@@ -32,6 +32,12 @@ type probedVideoInfo struct {
 }
 
 func (a *App) ProbeClipDuration(videoPath string) (float64, error) {
+	release, fileErr := a.beginManagedFileUse()
+	if fileErr != nil {
+		return 0, fileErr
+	}
+	defer release()
+
 	videoPath = strings.TrimSpace(videoPath)
 	if videoPath == "" {
 		return 0, fmt.Errorf("video path is empty")

--- a/internal/app/gameinfo_health.go
+++ b/internal/app/gameinfo_health.go
@@ -34,7 +34,16 @@ func (a *App) GetGameInfoHealth() (*GameInfoHealth, error) {
 }
 
 func (a *App) RepairGameInfo() (*GameInfoHealth, error) {
-	health, err := a.readGameInfoHealth()
+	if a == nil {
+		return unknownGameInfoHealth("", fmt.Errorf("工作目录尚未初始化")), nil
+	}
+	release, _, fileErr := a.beginManagedWorkspaceUse()
+	if fileErr != nil {
+		return unknownGameInfoHealth("", fileErr), nil
+	}
+	defer release()
+
+	health, err := a.readGameInfoHealthAtCurrentWorkspace()
 	if err != nil {
 		return nil, err
 	}
@@ -74,9 +83,25 @@ func (a *App) RepairGameInfo() (*GameInfoHealth, error) {
 }
 
 func (a *App) readGameInfoHealth() (*GameInfoHealth, error) {
-	if a == nil || (a.dataDir == "" && a.service == nil) {
+	if a == nil {
 		return unknownGameInfoHealth("", fmt.Errorf("工作目录尚未初始化")), nil
 	}
+	snapshot := a.workspaceSnapshot()
+	if snapshot.root == "" && snapshot.service == nil {
+		return unknownGameInfoHealth("", fmt.Errorf("工作目录尚未初始化")), nil
+	}
+	release, _, fileErr := a.beginManagedWorkspaceUse()
+	if fileErr != nil {
+		return unknownGameInfoHealth("", fileErr), nil
+	}
+	defer release()
+	return a.readGameInfoHealthAtCurrentWorkspace()
+}
+
+// readGameInfoHealthAtCurrentWorkspace must run under one workspace lease.
+// Callers that will use the returned path for a subsequent write (notably
+// RepairGameInfo) must keep that same lease until the write completes.
+func (a *App) readGameInfoHealthAtCurrentWorkspace() (*GameInfoHealth, error) {
 	cfg, err := a.loadConfig()
 	if err != nil {
 		return unknownGameInfoHealth("", fmt.Errorf("读取配置失败: %w", err)), nil

--- a/internal/app/outputs_storage.go
+++ b/internal/app/outputs_storage.go
@@ -23,6 +23,11 @@ type DemoStorageStats struct {
 }
 
 func (a *App) GetOutputsStorageStats() (*OutputsStorageStats, error) {
+	release, err := a.beginManagedFileUse()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return a.outputsStorageStats()
 }
 
@@ -41,11 +46,21 @@ func (a *App) ClearOutputsDirectory() (*OutputsStorageStats, error) {
 }
 
 func (a *App) OpenOutputsDirectory() error {
+	release, err := a.beginManagedFileUse()
+	if err != nil {
+		return err
+	}
+	defer release()
 	outputDir := a.fixedRecordOutputDir()
 	return openManagedDirectory(outputDir, "输出目录")
 }
 
 func (a *App) GetDemoStorageStats() (*DemoStorageStats, error) {
+	release, err := a.beginManagedFileUse()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 	return a.demoStorageStats()
 }
 
@@ -64,6 +79,11 @@ func (a *App) ClearDemoDirectory() (*DemoStorageStats, error) {
 }
 
 func (a *App) OpenDemoDirectory() error {
+	release, err := a.beginManagedFileUse()
+	if err != nil {
+		return err
+	}
+	defer release()
 	demoDir := a.demoStorageDir()
 	return openManagedDirectory(demoDir, "Dem 目录")
 }

--- a/internal/app/plugin_generate.go
+++ b/internal/app/plugin_generate.go
@@ -133,6 +133,10 @@ func (a *App) GetProduceTakeSnapshot() producews.TakeStatusSnapshot {
 	if a.produceW == nil {
 		return producews.TakeStatusSnapshot{}
 	}
+	snapshot := a.workspaceSnapshot()
+	if snapshot.pendingReset || snapshot.resetComplete || (snapshot.session != nil && snapshot.session.isClosed()) {
+		return producews.TakeStatusSnapshot{}
+	}
 	return a.produceW.GetTakeSnapshot()
 }
 
@@ -145,6 +149,11 @@ func (a *App) GeneratePluginJSONBatch(req GeneratePluginJSONBatchRequest) (*Gene
 	// state during setup.
 	a.produceLaunchMu.Lock()
 	defer a.produceLaunchMu.Unlock()
+	releaseWorkspace, _, workspaceErr := a.beginManagedWorkspaceUse()
+	if workspaceErr != nil {
+		return nil, workspaceErr
+	}
+	defer releaseWorkspace()
 	if len(req.Jobs) == 0 {
 		return nil, fmt.Errorf("没有可生成的 demo 任务")
 	}
@@ -208,6 +217,11 @@ func (a *App) GeneratePluginJSONBatchAndLaunchHLAE(req GeneratePluginJSONBatchRe
 	// environment.
 	a.produceLaunchMu.Lock()
 	defer a.produceLaunchMu.Unlock()
+	releaseWorkspace, _, workspaceErr := a.beginManagedWorkspaceUse()
+	if workspaceErr != nil {
+		return nil, workspaceErr
+	}
+	defer releaseWorkspace()
 	if len(req.Jobs) == 0 {
 		return nil, fmt.Errorf("没有可生成的 demo 任务")
 	}
@@ -487,6 +501,11 @@ func normalizeGeneratePluginBatchJobs(input []GeneratePluginJSONRequest) ([]Gene
 func (a *App) GeneratePluginJSON(req GeneratePluginJSONRequest) (*GeneratePluginJSONResult, error) {
 	a.produceLaunchMu.Lock()
 	defer a.produceLaunchMu.Unlock()
+	releaseWorkspace, _, workspaceErr := a.beginManagedWorkspaceUse()
+	if workspaceErr != nil {
+		return nil, workspaceErr
+	}
+	defer releaseWorkspace()
 	if err := a.produceBusyError(); err != nil {
 		return nil, err
 	}

--- a/internal/app/produce_logs.go
+++ b/internal/app/produce_logs.go
@@ -19,6 +19,11 @@ func (a *App) ExportProduceWSLogs() (string, error) {
 	if a == nil || a.produceW == nil {
 		return "", fmt.Errorf("制作 WebSocket 服务未初始化")
 	}
+	release, err := a.beginManagedFileUse()
+	if err != nil {
+		return "", err
+	}
+	defer release()
 	defaultDir := a.dataPath("logs")
 	if err := os.MkdirAll(defaultDir, 0o755); err != nil {
 		return "", fmt.Errorf("创建制作日志目录失败: %w", err)

--- a/internal/app/produce_takefile.go
+++ b/internal/app/produce_takefile.go
@@ -96,6 +96,12 @@ func (a *App) getProduceHistorySnapshot() ProduceHistorySnapshot {
 }
 
 func (a *App) OpenProducedClipInFolder(videoPath string) error {
+	release, fileErr := a.beginManagedExternalUse()
+	if fileErr != nil {
+		return fileErr
+	}
+	defer release()
+
 	target := strings.TrimSpace(videoPath)
 	if target == "" {
 		return fmt.Errorf("视频路径为空")

--- a/internal/app/produce_takefile.go
+++ b/internal/app/produce_takefile.go
@@ -114,7 +114,7 @@ func (a *App) OpenProducedClipInFolder(videoPath string) error {
 }
 
 func (a *App) ExportProduceHistoryVideos() (*ExportProduceHistoryResult, error) {
-	releaseFiles, fileErr := a.beginManagedFileUse()
+	releaseFiles, fileErr := a.beginManagedExternalUse()
 	if fileErr != nil {
 		return nil, fileErr
 	}

--- a/internal/app/work_activity.go
+++ b/internal/app/work_activity.go
@@ -1,6 +1,10 @@
 package app
 
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+	"sync"
+)
 
 // WorkActivity covers the whole produce lifecycle, not just the plugin queue.
 type WorkActivity struct {
@@ -42,23 +46,113 @@ func (a *App) produceBusyError() error {
 	return nil
 }
 
+// reserveManagedResourceLocked records one operation that may touch the
+// managed workspace. The caller must hold managedFilesMu. A once guard keeps
+// a repeated defer from corrupting the shared count.
+func (a *App) reserveManagedResourceLocked() func() {
+	a.managedFileUsers++
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			a.managedFilesMu.Lock()
+			if a.managedFileUsers > 0 {
+				a.managedFileUsers--
+			}
+			a.managedFilesMu.Unlock()
+		})
+	}
+}
+
+// reserveManagedWorkspaceTask is used by SetWorkspaceDir while it owns the
+// transition reservation. It intentionally bypasses managedFilesClearing:
+// the transition owner must register the goroutine it is about to launch
+// before releasing the exclusive reservation.
+func (a *App) reserveManagedWorkspaceTask() func() {
+	a.managedFilesMu.Lock()
+	release := a.reserveManagedResourceLocked()
+	a.managedFilesMu.Unlock()
+	return release
+}
+
+// managedWorkspaceRoot keeps the explicit non-Windows development fallback
+// used by headless tests and wails dev. Windows requires a selected dataDir;
+// exeDir is never treated as a user workspace there.
+func (a *App) managedWorkspaceRoot() string {
+	if a == nil {
+		return ""
+	}
+	a.serviceMu.Lock()
+	dataDir := a.dataDir
+	exeDir := a.exeDir
+	pending := a.workspaceResetPendingPath != "" || a.workspaceResetRegistryPending
+	resetCompleted := a.workspaceResetCompleted
+	a.serviceMu.Unlock()
+	if dataDir != "" {
+		return dataDir
+	}
+	if pending || resetCompleted {
+		return ""
+	}
+	if runtime.GOOS != "windows" {
+		return exeDir
+	}
+	return ""
+}
+
+// beginManagedWorkspaceUse reserves a stable workspace root for the duration
+// of one operation. The reservation prevents ResetWorkspace from changing
+// dataDir while the caller is doing I/O.
+func (a *App) beginManagedWorkspaceUse() (func(), string, error) {
+	if a == nil {
+		return nil, "", workspaceNotInitializedErr()
+	}
+	a.managedFilesMu.Lock()
+	defer a.managedFilesMu.Unlock()
+	if a.managedFilesClearing {
+		return nil, "", fmt.Errorf("正在清理目录，请完成后再试")
+	}
+	dataDir := a.managedWorkspaceRoot()
+	if dataDir == "" {
+		return nil, "", workspaceNotInitializedErr()
+	}
+	return a.reserveManagedResourceLocked(), dataDir, nil
+}
+
 // Reserve file use without holding a state mutex over I/O. Imports, parsing,
 // editing and exports may coexist; directory deletion must be exclusive.
 func (a *App) beginManagedFileUse() (func(), error) {
+	release, _, err := a.beginManagedWorkspaceUse()
+	return release, err
+}
+
+// beginManagedExternalUse protects an operation that does not need the
+// managed workspace root (for example copying a history video to a user
+// selected directory) but still must not overlap a reset.
+func (a *App) beginManagedExternalUse() (func(), error) {
+	if a == nil {
+		return nil, workspaceNotInitializedErr()
+	}
 	a.managedFilesMu.Lock()
 	defer a.managedFilesMu.Unlock()
 	if a.managedFilesClearing {
 		return nil, fmt.Errorf("正在清理目录，请完成后再试")
 	}
-	a.managedFileUsers++
-	return func() {
-		a.managedFilesMu.Lock()
-		a.managedFileUsers--
-		a.managedFilesMu.Unlock()
-	}, nil
+	return a.reserveManagedResourceLocked(), nil
 }
 
 func (a *App) beginManagedDirectoryClear() (func(), error) {
+	return a.beginManagedExclusion(true)
+}
+
+// beginWorkspaceTransition is the single admission gate for SetWorkspaceDir
+// and ResetWorkspace. It excludes file users and the produce launch pipeline,
+// and it remains held until the caller finishes all disk, registry and App
+// state changes.
+func (a *App) beginWorkspaceTransition() (func(), error) {
+	return a.beginManagedExclusion(false)
+}
+
+func (a *App) beginManagedExclusion(requireWorkspace bool) (func(), error) {
 	if !a.produceLaunchMu.TryLock() {
 		return nil, fmt.Errorf("正在启动制作或清理目录，请完成后再试")
 	}
@@ -73,6 +167,13 @@ func (a *App) beginManagedDirectoryClear() (func(), error) {
 		a.produceLaunchMu.Unlock()
 		return nil, fmt.Errorf("制作会话收尾尚未成功，请先重试制作以恢复环境")
 	}
+	if requireWorkspace {
+		dataDir := a.managedWorkspaceRoot()
+		if dataDir == "" {
+			a.produceLaunchMu.Unlock()
+			return nil, workspaceNotInitializedErr()
+		}
+	}
 	a.managedFilesMu.Lock()
 	if a.managedFileUsers > 0 || a.managedFilesClearing {
 		a.managedFilesMu.Unlock()
@@ -81,6 +182,21 @@ func (a *App) beginManagedDirectoryClear() (func(), error) {
 	}
 	a.managedFilesClearing = true
 	a.managedFilesMu.Unlock()
+
+	// App-owned startup calls are counted in managedFileUsers. This check also
+	// covers a Service task started directly by a test or another internal
+	// caller, so a reset cannot delete its data directory underneath it.
+	a.serviceMu.Lock()
+	svc := a.service
+	a.serviceMu.Unlock()
+	if svc != nil && svc.HasActiveTasks() {
+		a.managedFilesMu.Lock()
+		a.managedFilesClearing = false
+		a.managedFilesMu.Unlock()
+		a.produceLaunchMu.Unlock()
+		return nil, fmt.Errorf("启动检查或后台组件任务仍在运行，请完成后再试")
+	}
+
 	return func() {
 		a.managedFilesMu.Lock()
 		a.managedFilesClearing = false

--- a/internal/app/work_activity.go
+++ b/internal/app/work_activity.go
@@ -28,7 +28,9 @@ func (a *App) GetWorkActivity() WorkActivity {
 	a.managedFilesMu.Lock()
 	storageBusy := a.managedFileUsers > 0 || a.managedFilesClearing
 	a.managedFilesMu.Unlock()
-	return WorkActivity{ProduceBusy: busy, StorageBusy: busy || retained || storageBusy}
+	session := a.workspaceSnapshot().session
+	closing := session != nil && session.isClosed()
+	return WorkActivity{ProduceBusy: busy, StorageBusy: busy || retained || storageBusy || closing}
 }
 
 // Caller holds produceLaunchMu. Never cancel an active runtime to make room
@@ -68,10 +70,32 @@ func (a *App) reserveManagedResourceLocked() func() {
 // the transition owner must register the goroutine it is about to launch
 // before releasing the exclusive reservation.
 func (a *App) reserveManagedWorkspaceTask() func() {
+	return a.reserveManagedWorkspaceTaskForSession(a.workspaceSnapshot().session)
+}
+
+// reserveManagedWorkspaceTaskForSession registers an app-owned background
+// task before its goroutine is started. The managed-file count keeps Reset's
+// existing rejection semantics while the session task gate lets Shutdown
+// cancel and wait without losing the immutable workspace root.
+func (a *App) reserveManagedWorkspaceTaskForSession(session *workspaceSession) func() {
 	a.managedFilesMu.Lock()
-	release := a.reserveManagedResourceLocked()
+	var releaseSession func()
+	if session != nil {
+		var ok bool
+		_, releaseSession, ok = session.beginTask()
+		if !ok {
+			a.managedFilesMu.Unlock()
+			return func() {}
+		}
+	}
+	releaseManaged := a.reserveManagedResourceLocked()
 	a.managedFilesMu.Unlock()
-	return release
+	return func() {
+		if releaseSession != nil {
+			releaseSession()
+		}
+		releaseManaged()
+	}
 }
 
 // managedWorkspaceRoot keeps the explicit non-Windows development fallback
@@ -81,20 +105,21 @@ func (a *App) managedWorkspaceRoot() string {
 	if a == nil {
 		return ""
 	}
-	a.serviceMu.Lock()
-	dataDir := a.dataDir
-	exeDir := a.exeDir
-	pending := a.workspaceResetPendingPath != "" || a.workspaceResetRegistryPending
-	resetCompleted := a.workspaceResetCompleted
-	a.serviceMu.Unlock()
-	if dataDir != "" {
-		return dataDir
+	snapshot := a.workspaceSnapshot()
+	if snapshot.session != nil {
+		if snapshot.session.isClosed() {
+			return ""
+		}
+		return snapshot.root
 	}
-	if pending || resetCompleted {
+	if snapshot.root != "" {
+		return snapshot.root
+	}
+	if snapshot.pendingReset || snapshot.resetComplete {
 		return ""
 	}
 	if runtime.GOOS != "windows" {
-		return exeDir
+		return snapshot.exeDir
 	}
 	return ""
 }
@@ -106,16 +131,40 @@ func (a *App) beginManagedWorkspaceUse() (func(), string, error) {
 	if a == nil {
 		return nil, "", workspaceNotInitializedErr()
 	}
+	session := a.ensureWorkspaceSession()
+	snapshot := a.workspaceSnapshot()
 	a.managedFilesMu.Lock()
-	defer a.managedFilesMu.Unlock()
 	if a.managedFilesClearing {
+		a.managedFilesMu.Unlock()
 		return nil, "", fmt.Errorf("正在清理目录，请完成后再试")
 	}
-	dataDir := a.managedWorkspaceRoot()
+	dataDir := snapshot.root
+	if session != nil {
+		dataDir = session.root
+	} else if dataDir == "" && !snapshot.pendingReset && !snapshot.resetComplete && runtime.GOOS != "windows" {
+		dataDir = snapshot.exeDir
+	}
 	if dataDir == "" {
+		a.managedFilesMu.Unlock()
 		return nil, "", workspaceNotInitializedErr()
 	}
-	return a.reserveManagedResourceLocked(), dataDir, nil
+	var releaseSession func()
+	if session != nil {
+		var ok bool
+		_, releaseSession, ok = session.beginTask()
+		if !ok {
+			a.managedFilesMu.Unlock()
+			return nil, "", fmt.Errorf("工作目录正在关闭，请完成后再试")
+		}
+	}
+	releaseManaged := a.reserveManagedResourceLocked()
+	a.managedFilesMu.Unlock()
+	return func() {
+		if releaseSession != nil {
+			releaseSession()
+		}
+		releaseManaged()
+	}, dataDir, nil
 }
 
 // Reserve file use without holding a state mutex over I/O. Imports, parsing,
@@ -132,12 +181,27 @@ func (a *App) beginManagedExternalUse() (func(), error) {
 	if a == nil {
 		return nil, workspaceNotInitializedErr()
 	}
+	session := a.ensureWorkspaceSession()
 	a.managedFilesMu.Lock()
 	defer a.managedFilesMu.Unlock()
 	if a.managedFilesClearing {
 		return nil, fmt.Errorf("正在清理目录，请完成后再试")
 	}
-	return a.reserveManagedResourceLocked(), nil
+	var releaseSession func()
+	if session != nil {
+		var ok bool
+		_, releaseSession, ok = session.beginTask()
+		if !ok {
+			return nil, fmt.Errorf("工作目录正在关闭，请完成后再试")
+		}
+	}
+	releaseManaged := a.reserveManagedResourceLocked()
+	return func() {
+		if releaseSession != nil {
+			releaseSession()
+		}
+		releaseManaged()
+	}, nil
 }
 
 func (a *App) beginManagedDirectoryClear() (func(), error) {
@@ -160,6 +224,7 @@ func (a *App) beginManagedExclusion(requireWorkspace bool) (func(), error) {
 		a.produceLaunchMu.Unlock()
 		return nil, err
 	}
+	snapshot := a.workspaceSnapshot()
 	a.produceStateMu.Lock()
 	runtime := a.produceState.runtime
 	a.produceStateMu.Unlock()
@@ -168,7 +233,10 @@ func (a *App) beginManagedExclusion(requireWorkspace bool) (func(), error) {
 		return nil, fmt.Errorf("制作会话收尾尚未成功，请先重试制作以恢复环境")
 	}
 	if requireWorkspace {
-		dataDir := a.managedWorkspaceRoot()
+		dataDir := snapshot.root
+		if snapshot.session != nil && snapshot.session.isClosed() {
+			dataDir = ""
+		}
 		if dataDir == "" {
 			a.produceLaunchMu.Unlock()
 			return nil, workspaceNotInitializedErr()
@@ -186,9 +254,7 @@ func (a *App) beginManagedExclusion(requireWorkspace bool) (func(), error) {
 	// App-owned startup calls are counted in managedFileUsers. This check also
 	// covers a Service task started directly by a test or another internal
 	// caller, so a reset cannot delete its data directory underneath it.
-	a.serviceMu.Lock()
-	svc := a.service
-	a.serviceMu.Unlock()
+	svc := snapshot.service
 	if svc != nil && svc.HasActiveTasks() {
 		a.managedFilesMu.Lock()
 		a.managedFilesClearing = false
@@ -203,4 +269,23 @@ func (a *App) beginManagedExclusion(requireWorkspace bool) (func(), error) {
 		a.managedFilesMu.Unlock()
 		a.produceLaunchMu.Unlock()
 	}, nil
+}
+
+// beginWorkspaceShutdown blocks new launch/file admission but intentionally
+// does not reject existing users. Shutdown needs those users to drain while
+// the workspace session cancels and waits for its own background work.
+func (a *App) beginWorkspaceShutdown() func() {
+	if a == nil {
+		return nil
+	}
+	a.produceLaunchMu.Lock()
+	a.managedFilesMu.Lock()
+	a.managedFilesClearing = true
+	a.managedFilesMu.Unlock()
+	return func() {
+		a.managedFilesMu.Lock()
+		a.managedFilesClearing = false
+		a.managedFilesMu.Unlock()
+		a.produceLaunchMu.Unlock()
+	}
 }

--- a/internal/app/workspace_lifecycle_test.go
+++ b/internal/app/workspace_lifecycle_test.go
@@ -1,0 +1,170 @@
+package app
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"cs2-highlight-tool-v2/internal/envsetup"
+	"cs2-highlight-tool-v2/internal/producews"
+)
+
+func newWorkspaceLifecycleTestApp(t *testing.T, dataDir string) *App {
+	t.Helper()
+	exeDir := t.TempDir()
+	return &App{
+		exeDir:   exeDir,
+		dataDir:  dataDir,
+		service:  envsetup.NewWithDataDir(exeDir, dataDir, "test"),
+		produceW: producews.NewDefault(nil),
+	}
+}
+
+func TestResetWorkspaceRejectsManagedFileUseAndPreservesWorkspace(t *testing.T) {
+	dataDir := t.TempDir()
+	sentinel := filepath.Join(dataDir, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := newWorkspaceLifecycleTestApp(t, dataDir)
+	originalService := a.service
+
+	release, err := a.beginManagedFileUse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	resetErr := a.ResetWorkspace()
+	if resetErr == nil || !strings.Contains(resetErr.Error(), "正在使用文件") {
+		t.Fatalf("ResetWorkspace error = %v, want managed-use rejection", resetErr)
+	}
+	if got, readErr := os.ReadFile(sentinel); readErr != nil || string(got) != "keep me" {
+		t.Fatalf("sentinel changed after rejected reset: %q, %v", got, readErr)
+	}
+	if a.dataDir != dataDir || a.service != originalService {
+		t.Fatalf("workspace changed after rejected reset: dataDir=%q service_same=%v", a.dataDir, a.service == originalService)
+	}
+
+	release()
+	if err := a.ResetWorkspace(); err != nil {
+		t.Fatalf("ResetWorkspace after release: %v", err)
+	}
+	if _, err := os.Stat(dataDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dataDir still exists after successful reset: %v", err)
+	}
+	if state := a.GetWorkspaceState(); state.Initialized || state.DataDir != "" {
+		t.Fatalf("workspace state after reset: %+v", state)
+	}
+	if runtime.GOOS != "windows" {
+		if _, err := a.beginManagedFileUse(); err == nil || !strings.Contains(err.Error(), "工作目录") {
+			t.Fatalf("reset workspace unexpectedly fell back to exeDir: %v", err)
+		}
+	}
+}
+
+func TestSetWorkspaceDirRejectsInitializedAppBeforePathSideEffects(t *testing.T) {
+	dataDir := t.TempDir()
+	a := newWorkspaceLifecycleTestApp(t, dataDir)
+	originalService := a.service
+	target := filepath.Join(t.TempDir(), "new-workspace")
+
+	err := a.SetWorkspaceDir(target)
+	if err == nil || !strings.Contains(err.Error(), "已初始化") {
+		t.Fatalf("SetWorkspaceDir error = %v, want initialized rejection", err)
+	}
+	if _, statErr := os.Stat(target); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("rejected SetWorkspaceDir touched target: %v", statErr)
+	}
+	if a.dataDir != dataDir || a.service != originalService {
+		t.Fatalf("workspace changed after rejected set: dataDir=%q service_same=%v", a.dataDir, a.service == originalService)
+	}
+}
+
+func TestResetWorkspaceRejectsRegisteredBackgroundTask(t *testing.T) {
+	dataDir := t.TempDir()
+	a := newWorkspaceLifecycleTestApp(t, dataDir)
+
+	// This is the same reservation used by SetWorkspaceDir before it launches
+	// RunStartupChecks. It models a blocked startup task without network or CS2.
+	releaseTask := a.reserveManagedWorkspaceTask()
+
+	err := a.ResetWorkspace()
+	if err == nil || !strings.Contains(err.Error(), "正在使用文件") {
+		t.Fatalf("ResetWorkspace error = %v, want registered-task rejection", err)
+	}
+	if _, statErr := os.Stat(dataDir); statErr != nil {
+		t.Fatalf("dataDir changed while task was registered: %v", statErr)
+	}
+	releaseTask()
+	if err := a.ResetWorkspace(); err != nil {
+		t.Fatalf("ResetWorkspace after background task exits: %v", err)
+	}
+	if _, statErr := os.Stat(dataDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("dataDir still exists after task release: %v", statErr)
+	}
+}
+
+func TestResetWorkspaceDetachesServiceWhenRemovalFailsAndCanRetry(t *testing.T) {
+	dataDir := t.TempDir()
+	sentinel := filepath.Join(dataDir, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("preserve for retry"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := newWorkspaceLifecycleTestApp(t, dataDir)
+	originalRemove := removeWorkspaceDir
+	removeWorkspaceDir = func(string) error { return errors.New("remove blocked") }
+	t.Cleanup(func() { removeWorkspaceDir = originalRemove })
+
+	if err := a.ResetWorkspace(); err == nil || !strings.Contains(err.Error(), "删除工作目录失败") {
+		t.Fatalf("first reset error = %v, want removal failure", err)
+	}
+	if a.service != nil || a.dataDir != "" || a.workspaceResetPendingPath != dataDir {
+		t.Fatalf("failed reset left old workspace operational: service=%v dataDir=%q pending=%q", a.service, a.dataDir, a.workspaceResetPendingPath)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("sentinel missing after injected failure: %v", err)
+	}
+
+	removeWorkspaceDir = os.RemoveAll
+	if err := a.ResetWorkspace(); err != nil {
+		t.Fatalf("retry reset: %v", err)
+	}
+	if _, err := os.Stat(dataDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dataDir still exists after retry: %v", err)
+	}
+}
+
+func TestResetWorkspaceRejectsFailedProduceTeardown(t *testing.T) {
+	dataDir := t.TempDir()
+	sentinel := filepath.Join(dataDir, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("keep during teardown retry"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := newWorkspaceLifecycleTestApp(t, dataDir)
+	done := make(chan struct{})
+	close(done)
+	a.produceState.runtime = &produceSessionRuntime{
+		done:        done,
+		teardownErr: errors.New("teardown still owns backups"),
+	}
+
+	err := a.ResetWorkspace()
+	if err == nil || !strings.Contains(err.Error(), "收尾尚未成功") {
+		t.Fatalf("ResetWorkspace error = %v, want failed-teardown rejection", err)
+	}
+	if _, statErr := os.Stat(sentinel); statErr != nil {
+		t.Fatalf("sentinel missing after failed-teardown rejection: %v", statErr)
+	}
+}
+
+func TestManagedWorkspaceUseRequiresSelectedDirectoryOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only selected-directory behavior")
+	}
+	a := &App{exeDir: t.TempDir()}
+	if _, err := a.beginManagedFileUse(); err == nil || !strings.Contains(err.Error(), "工作目录") {
+		t.Fatalf("beginManagedFileUse error = %v, want uninitialized workspace error", err)
+	}
+}

--- a/internal/app/workspace_session.go
+++ b/internal/app/workspace_session.go
@@ -1,0 +1,256 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"cs2-highlight-tool-v2/internal/envsetup"
+)
+
+var workspaceSessionStopWait = 10 * time.Second
+
+// workspaceSession is the private identity of one selected workspace. Its
+// root, generation and envsetup service never change for the lifetime of the
+// instance. App keeps legacy fields as mirrors for the Wails-facing code and
+// older focused tests, but new work snapshots this object before doing I/O.
+type workspaceSession struct {
+	root       string
+	generation uint64
+	service    *envsetup.Service
+	ctx        context.Context
+	cancel     context.CancelFunc
+
+	taskMu      sync.Mutex
+	activeTasks int
+	tasksClosed bool
+	taskWG      sync.WaitGroup
+}
+
+func newWorkspaceSession(root string, generation uint64, service *envsetup.Service) *workspaceSession {
+	ctx, cancel := context.WithCancel(context.Background())
+	session := &workspaceSession{
+		root:       root,
+		generation: generation,
+		service:    service,
+		ctx:        ctx,
+		cancel:     cancel,
+	}
+	if service != nil {
+		service.BindLifecycleContext(ctx)
+	}
+	return session
+}
+
+func (s *workspaceSession) isClosed() bool {
+	if s == nil {
+		return true
+	}
+	s.taskMu.Lock()
+	closed := s.tasksClosed
+	s.taskMu.Unlock()
+	return closed
+}
+
+// beginTask admits one app-owned operation and returns the immutable
+// lifecycle context it belongs to. The registration happens before callers
+// launch a goroutine, so close cannot race Wait with Add.
+func (s *workspaceSession) beginTask() (context.Context, func(), bool) {
+	if s == nil {
+		return context.Background(), func() {}, false
+	}
+	s.taskMu.Lock()
+	if s.tasksClosed {
+		ctx := s.ctx
+		s.taskMu.Unlock()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		return ctx, func() {}, false
+	}
+	s.activeTasks++
+	s.taskWG.Add(1)
+	ctx := s.ctx
+	s.taskMu.Unlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var once sync.Once
+	return ctx, func() {
+		once.Do(func() {
+			s.taskMu.Lock()
+			if s.activeTasks > 0 {
+				s.activeTasks--
+			}
+			s.taskMu.Unlock()
+			s.taskWG.Done()
+		})
+	}, true
+}
+
+// closeIfIdle atomically closes app admission and the envsetup admission only
+// when no task is active. Reset uses this non-canceling path: active user work
+// is rejected by the outer App gate and must finish before deletion.
+func (s *workspaceSession) closeIfIdle() bool {
+	if s == nil {
+		return true
+	}
+	s.taskMu.Lock()
+	if s.tasksClosed {
+		idle := s.activeTasks == 0
+		s.taskMu.Unlock()
+		if !idle || s.service == nil {
+			return idle
+		}
+		return s.service.CloseIfIdle()
+	}
+	if s.activeTasks > 0 {
+		s.taskMu.Unlock()
+		return false
+	}
+	if s.service != nil && !s.service.CloseIfIdle() {
+		s.taskMu.Unlock()
+		return false
+	}
+	s.tasksClosed = true
+	cancel := s.cancel
+	s.taskMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return true
+}
+
+// close cancels the session and waits for all app-owned work. It is used by
+// application shutdown; a timeout leaves the session closed so no new work
+// can enter and a later call can retry the wait.
+func (s *workspaceSession) close(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.taskMu.Lock()
+	if !s.tasksClosed {
+		s.tasksClosed = true
+	}
+	cancel := s.cancel
+	s.taskMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	stopCtx := ctx
+	if _, hasDeadline := stopCtx.Deadline(); !hasDeadline {
+		var stopCancel context.CancelFunc
+		stopCtx, stopCancel = context.WithTimeout(stopCtx, workspaceSessionStopWait)
+		defer stopCancel()
+	}
+	if s.service != nil {
+		if err := s.service.Stop(stopCtx); err != nil {
+			return err
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.taskWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-stopCtx.Done():
+		return fmt.Errorf("停止工作目录任务超时: %w", stopCtx.Err())
+	}
+}
+
+type workspaceSnapshot struct {
+	session       *workspaceSession
+	service       *envsetup.Service
+	root          string
+	generation    uint64
+	exeDir        string
+	pendingReset  bool
+	resetComplete bool
+}
+
+// workspaceSnapshot reads the short-lived App identity lock only. Callers
+// must use the returned root/service for the whole operation and must not
+// reacquire serviceMu while holding a file/activity lock.
+func (a *App) workspaceSnapshot() workspaceSnapshot {
+	if a == nil {
+		return workspaceSnapshot{}
+	}
+	a.serviceMu.Lock()
+	snapshot := workspaceSnapshot{
+		session:       a.workspace,
+		service:       a.service,
+		root:          a.dataDir,
+		generation:    a.workspaceGeneration,
+		exeDir:        a.exeDir,
+		pendingReset:  a.workspaceResetPendingPath != "" || a.workspaceResetRegistryPending,
+		resetComplete: a.workspaceResetCompleted,
+	}
+	a.serviceMu.Unlock()
+	if snapshot.session != nil {
+		snapshot.root = snapshot.session.root
+		snapshot.service = snapshot.session.service
+		snapshot.generation = snapshot.session.generation
+	}
+	return snapshot
+}
+
+// ensureWorkspaceSessionLocked lazily upgrades manually constructed App
+// fixtures (which still set service/dataDir directly) to the same identity and
+// task gate used by production construction. The caller must hold serviceMu.
+func (a *App) ensureWorkspaceSessionLocked() *workspaceSession {
+	if a == nil || a.workspace != nil || a.service == nil || a.dataDir == "" {
+		if a == nil {
+			return nil
+		}
+		return a.workspace
+	}
+	a.workspaceGeneration++
+	a.workspace = newWorkspaceSession(a.dataDir, a.workspaceGeneration, a.service)
+	return a.workspace
+}
+
+func (a *App) ensureWorkspaceSession() *workspaceSession {
+	if a == nil {
+		return nil
+	}
+	a.serviceMu.Lock()
+	session := a.ensureWorkspaceSessionLocked()
+	a.serviceMu.Unlock()
+	return session
+}
+
+// installWorkspaceLocked installs a new immutable workspace identity. The
+// caller must hold serviceMu and must have already passed the lifecycle gate.
+func (a *App) installWorkspaceLocked(root string, service *envsetup.Service) *workspaceSession {
+	a.workspaceGeneration++
+	session := newWorkspaceSession(root, a.workspaceGeneration, service)
+	a.workspace = session
+	a.dataDir = root
+	a.service = service
+	a.workspaceResetPendingPath = ""
+	a.workspaceResetRegistryPending = false
+	a.workspaceResetCompleted = false
+	return session
+}
+
+// clearProduceWorkspaceState drops in-memory take/history indexes that belong
+// to the removed workspace. The existing snapshot events make the frontend
+// discard the old list immediately after a successful reset.
+func (a *App) clearProduceWorkspaceState() {
+	if a == nil {
+		return
+	}
+	a.produceStateMu.Lock()
+	a.produceState = produceSessionState{}
+	a.produceStateMu.Unlock()
+	a.emitTakeFilesSnapshot(ProduceTakeFileSnapshot{Items: make([]ProduceTakeFile, 0), UpdatedAtMs: nowMs()})
+	a.emitProduceHistorySnapshot(ProduceHistorySnapshot{Items: make([]ProduceHistoryItem, 0), UpdatedAtMs: nowMs()})
+}

--- a/internal/app/workspace_session_test.go
+++ b/internal/app/workspace_session_test.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cs2-highlight-tool-v2/internal/envsetup"
+)
+
+func TestWorkspaceSessionCloseCancelsTasksAndRejectsNewWork(t *testing.T) {
+	root := t.TempDir()
+	svc := envsetup.NewWithDataDir(t.TempDir(), root, "test")
+	session := newWorkspaceSession(root, 1, svc)
+
+	taskCtx, release, ok := session.beginTask()
+	if !ok {
+		t.Fatal("session task was not admitted")
+	}
+	taskDone := make(chan struct{})
+	go func() {
+		<-taskCtx.Done()
+		release()
+		close(taskDone)
+	}()
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := session.close(stopCtx); err != nil {
+		t.Fatalf("session.close: %v", err)
+	}
+	select {
+	case <-taskDone:
+	case <-time.After(time.Second):
+		t.Fatal("session task did not observe cancellation")
+	}
+	if _, _, admitted := session.beginTask(); admitted {
+		t.Fatal("closed session admitted a new task")
+	}
+}
+
+func TestResetWorkspaceClearsProduceIndexes(t *testing.T) {
+	dataDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dataDir, "sentinel.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := newWorkspaceLifecycleTestApp(t, dataDir)
+	a.produceState.takeFiles = map[string]ProduceTakeFile{
+		"take": {DemoPath: "demo", TakeIndex: 1, Status: "ready"},
+	}
+	a.produceState.takeFileOrder = []string{"take"}
+	a.produceState.historyItems = map[string]ProduceHistoryItem{
+		"history": {DemoPath: "demo", TakeIndex: 1, VideoPath: "clip.mp4"},
+	}
+	a.produceState.historyOrder = []string{"history"}
+	a.produceState.historyKeyIndex = map[string]struct{}{"history": {}}
+
+	if err := a.ResetWorkspace(); err != nil {
+		t.Fatalf("ResetWorkspace: %v", err)
+	}
+	a.produceStateMu.Lock()
+	defer a.produceStateMu.Unlock()
+	if len(a.produceState.takeFiles) != 0 || len(a.produceState.historyItems) != 0 || len(a.produceState.historyKeyIndex) != 0 {
+		t.Fatalf("workspace indexes were not cleared: %+v", a.produceState)
+	}
+}

--- a/internal/envsetup/events.go
+++ b/internal/envsetup/events.go
@@ -3,14 +3,14 @@ package envsetup
 import "github.com/wailsapp/wails/v2/pkg/runtime"
 
 func (s *Service) emitState() {
-	if s.ctx == nil {
+	if s == nil || s.isStopped() || s.ctx == nil {
 		return
 	}
 	runtime.EventsEmit(s.ctx, "startup_state_changed", s.GetStartupState())
 }
 
 func (s *Service) emitProgress(componentID string, active bool, percent float64, indeterminate bool) {
-	if s.ctx == nil {
+	if s == nil || s.isStopped() || s.ctx == nil {
 		return
 	}
 	runtime.EventsEmit(s.ctx, "download_progress", ProgressMessage{

--- a/internal/envsetup/ffmpeg.go
+++ b/internal/envsetup/ffmpeg.go
@@ -175,6 +175,7 @@ func (s *Service) scheduleFFmpegCapabilityDetection(ffmpegExe string) {
 		return
 	}
 	detectCtx, cancel := context.WithCancel(context.Background())
+	releaseTask := s.beginTask()
 	s.ffmpegDetectRunning = true
 	s.ffmpegDetectCancel = cancel
 	s.ffmpegDetectWG.Add(1)
@@ -182,6 +183,7 @@ func (s *Service) scheduleFFmpegCapabilityDetection(ffmpegExe string) {
 
 	ffmpegDetectAsyncRunner(func() {
 		defer func() {
+			releaseTask()
 			s.ffmpegDetectMu.Lock()
 			s.ffmpegDetectRunning = false
 			s.ffmpegDetectCancel = nil

--- a/internal/envsetup/ffmpeg.go
+++ b/internal/envsetup/ffmpeg.go
@@ -174,11 +174,17 @@ func (s *Service) scheduleFFmpegCapabilityDetection(ffmpegExe string) {
 		})
 		return
 	}
-	detectCtx, cancel := context.WithCancel(context.Background())
-	releaseTask := s.beginTask()
+	detectCtx, releaseTask, ok := s.beginTaskIfOpen()
+	if !ok {
+		s.ffmpegDetectMu.Unlock()
+		return
+	}
 	s.ffmpegDetectRunning = true
-	s.ffmpegDetectCancel = cancel
+	// Keep a dedicated cancel for reinstall while deriving the task from the
+	// service lifecycle context. The probe exits when either one is canceled.
+	probeCtx, probeCancel := context.WithCancel(detectCtx)
 	s.ffmpegDetectWG.Add(1)
+	s.ffmpegDetectCancel = probeCancel
 	s.ffmpegDetectMu.Unlock()
 
 	ffmpegDetectAsyncRunner(func() {
@@ -190,7 +196,7 @@ func (s *Service) scheduleFFmpegCapabilityDetection(ffmpegExe string) {
 			s.ffmpegDetectMu.Unlock()
 			s.ffmpegDetectWG.Done()
 		}()
-		s.detectAndCacheFFmpegCapabilities(detectCtx, ffmpegExe)
+		s.detectAndCacheFFmpegCapabilities(probeCtx, ffmpegExe)
 	})
 }
 
@@ -213,12 +219,18 @@ func (s *Service) stopFFmpegCapabilityDetection() {
 
 func (s *Service) detectAndCacheFFmpegCapabilities(ctx context.Context, ffmpegExe string) {
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = s.lifecycleContext()
+	}
+	if s.isStopped() {
+		return
 	}
 	started := s.logStepStart(componentFFmpeg, "detect_profile", "probe_encoders", string(s.currentSource()), 0, map[string]string{
 		"ffmpeg_exe": ffmpegExe,
 	})
 	caps, err := ffmpegprofile.DetectCapabilities(ctx, ffmpegExe, ffmpegDetectCommandContext)
+	if s.isStopped() {
+		return
+	}
 	if errors.Is(err, context.Canceled) {
 		s.logStepDone(componentFFmpeg, "detect_profile", "probe_encoders", string(s.currentSource()), 0, started, map[string]string{
 			"canceled": "true",

--- a/internal/envsetup/ffmpeg_detect_test.go
+++ b/internal/envsetup/ffmpeg_detect_test.go
@@ -282,6 +282,9 @@ func TestStopFFmpegCapabilityDetectionCancelsRunningProbe(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("probe did not start")
 	}
+	if !svc.HasActiveTasks() {
+		t.Fatal("active FFmpeg probe was not registered as a service task")
+	}
 
 	start := time.Now()
 	svc.stopFFmpegCapabilityDetection()
@@ -289,6 +292,9 @@ func TestStopFFmpegCapabilityDetectionCancelsRunningProbe(t *testing.T) {
 		t.Fatalf("stopFFmpegCapabilityDetection elapsed=%s, want under 1s", elapsed)
 	}
 	waitFFmpegDetectDone(t, svc, 2*time.Second)
+	if svc.HasActiveTasks() {
+		t.Fatal("service task remained active after FFmpeg probe stopped")
+	}
 
 	cfg, err := config.LoadOrCreate(filepath.Join(exeDir, "config.json"), exeDir)
 	if err != nil {

--- a/internal/envsetup/logger_bridge.go
+++ b/internal/envsetup/logger_bridge.go
@@ -95,6 +95,9 @@ func (s *Service) logStepFail(component, stage, action, source string, attempt i
 }
 
 func (s *Service) appendLogEntry(entry logging.Entry) {
+	if s == nil || s.isStopped() {
+		return
+	}
 	logEntry := LogMessage{
 		Level:     strings.TrimSpace(entry.Level),
 		Message:   strings.TrimSpace(entry.Message),

--- a/internal/envsetup/service.go
+++ b/internal/envsetup/service.go
@@ -35,6 +35,12 @@ type Service struct {
 	ffmpegDetectRunning bool
 	ffmpegDetectCancel  context.CancelFunc
 	ffmpegDetectWG      sync.WaitGroup
+
+	// activeTasks covers synchronous startup actions and child work that may
+	// outlive their parent call (currently the FFmpeg capability probe). App
+	// uses it as a final guard before deleting the workspace.
+	taskMu      sync.Mutex
+	activeTasks int
 }
 
 type activeDownloadCancel struct {
@@ -65,6 +71,37 @@ func NewWithDataDir(exeDir string, dataDir string, version string) *Service {
 	})
 	s.runTasksFn = s.runTasksDefault
 	return s
+}
+
+func (s *Service) beginTask() func() {
+	if s == nil {
+		return func() {}
+	}
+	s.taskMu.Lock()
+	s.activeTasks++
+	s.taskMu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			s.taskMu.Lock()
+			if s.activeTasks > 0 {
+				s.activeTasks--
+			}
+			s.taskMu.Unlock()
+		})
+	}
+}
+
+// HasActiveTasks reports startup work that can still read or write the
+// service's data directory. It is intentionally a snapshot; callers that
+// need exclusion must hold the App workspace admission gate as well.
+func (s *Service) HasActiveTasks() bool {
+	if s == nil {
+		return false
+	}
+	s.taskMu.Lock()
+	defer s.taskMu.Unlock()
+	return s.activeTasks > 0
 }
 
 func (s *Service) Startup(ctx context.Context) {

--- a/internal/envsetup/service.go
+++ b/internal/envsetup/service.go
@@ -2,9 +2,11 @@ package envsetup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"cs2-highlight-tool-v2/internal/config"
 	"cs2-highlight-tool-v2/internal/logging"
@@ -39,9 +41,20 @@ type Service struct {
 	// activeTasks covers synchronous startup actions and child work that may
 	// outlive their parent call (currently the FFmpeg capability probe). App
 	// uses it as a final guard before deleting the workspace.
-	taskMu      sync.Mutex
-	activeTasks int
+	taskMu          sync.Mutex
+	activeTasks     int
+	taskWG          sync.WaitGroup
+	tasksClosed     bool
+	lifecycleCtx    context.Context
+	lifecycleCancel context.CancelFunc
 }
+
+// serviceStopWait bounds a stop request that did not receive a context with a
+// deadline. A closed service remains closed after this timeout; callers can
+// retry Stop later without reopening admission for the old workspace.
+var serviceStopWait = 10 * time.Second
+
+var errServiceStopped = errors.New("工作目录服务已停止")
 
 type activeDownloadCancel struct {
 	cancel context.CancelFunc
@@ -57,14 +70,17 @@ func NewWithDataDir(exeDir string, dataDir string, version string) *Service {
 		dataDir = exeDir
 	}
 	cfg := config.Default(dataDir)
+	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 	s := &Service{
-		exeDir:     exeDir,
-		dataDir:    dataDir,
-		configPath: filepath.Join(dataDir, "config.json"),
-		config:     cfg,
-		version:    version,
-		state:      newStartupState(cfg, version),
-		cancelMap:  make(map[string]*activeDownloadCancel),
+		exeDir:          exeDir,
+		dataDir:         dataDir,
+		configPath:      filepath.Join(dataDir, "config.json"),
+		config:          cfg,
+		version:         version,
+		state:           newStartupState(cfg, version),
+		cancelMap:       make(map[string]*activeDownloadCancel),
+		lifecycleCtx:    lifecycleCtx,
+		lifecycleCancel: lifecycleCancel,
 	}
 	s.logger = logging.NewSlogAdapter(logging.Options{
 		Sink: s.appendLogEntry,
@@ -73,23 +89,92 @@ func NewWithDataDir(exeDir string, dataDir string, version string) *Service {
 	return s
 }
 
-func (s *Service) beginTask() func() {
+// BindLifecycleContext attaches a workspace-owned parent context to this
+// service. It is intentionally called by the app's private workspace session,
+// not exposed as a Wails method. A service with active work or a closed
+// admission gate cannot be rebound, which keeps an old instance from being
+// silently reused by a new workspace.
+func (s *Service) BindLifecycleContext(parent context.Context) {
 	if s == nil {
-		return func() {}
+		return
+	}
+	if parent == nil {
+		parent = context.Background()
 	}
 	s.taskMu.Lock()
-	s.activeTasks++
+	if s.tasksClosed || s.activeTasks > 0 {
+		s.taskMu.Unlock()
+		return
+	}
+	oldCancel := s.lifecycleCancel
+	lifecycleCtx, lifecycleCancel := context.WithCancel(parent)
+	s.lifecycleCtx = lifecycleCtx
+	s.lifecycleCancel = lifecycleCancel
 	s.taskMu.Unlock()
+	if oldCancel != nil {
+		oldCancel()
+	}
+}
+
+func (s *Service) lifecycleContext() context.Context {
+	if s == nil {
+		return context.Background()
+	}
+	s.taskMu.Lock()
+	ctx := s.lifecycleCtx
+	s.taskMu.Unlock()
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
+
+func (s *Service) isStopped() bool {
+	if s == nil {
+		return true
+	}
+	s.taskMu.Lock()
+	closed := s.tasksClosed
+	s.taskMu.Unlock()
+	return closed
+}
+
+func (s *Service) beginTaskIfOpen() (context.Context, func(), bool) {
+	if s == nil {
+		return context.Background(), func() {}, false
+	}
+	s.taskMu.Lock()
+	if s.tasksClosed {
+		ctx := s.lifecycleCtx
+		s.taskMu.Unlock()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		return ctx, func() {}, false
+	}
+	s.activeTasks++
+	s.taskWG.Add(1)
+	ctx := s.lifecycleCtx
+	s.taskMu.Unlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var once sync.Once
-	return func() {
+	return ctx, func() {
 		once.Do(func() {
 			s.taskMu.Lock()
 			if s.activeTasks > 0 {
 				s.activeTasks--
 			}
 			s.taskMu.Unlock()
+			s.taskWG.Done()
 		})
-	}
+	}, true
+}
+
+func (s *Service) beginTask() func() {
+	_, release, _ := s.beginTaskIfOpen()
+	return release
 }
 
 // HasActiveTasks reports startup work that can still read or write the
@@ -104,7 +189,77 @@ func (s *Service) HasActiveTasks() bool {
 	return s.activeTasks > 0
 }
 
+// CloseIfIdle atomically stops task admission only when no task is active.
+// Reset uses this non-canceling boundary so an active user operation is
+// rejected rather than forcefully interrupted before deletion.
+func (s *Service) CloseIfIdle() bool {
+	if s == nil {
+		return true
+	}
+	s.taskMu.Lock()
+	if s.tasksClosed || s.activeTasks > 0 {
+		closed := s.tasksClosed && s.activeTasks == 0
+		s.taskMu.Unlock()
+		return closed
+	}
+	s.tasksClosed = true
+	cancel := s.lifecycleCancel
+	s.taskMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return true
+}
+
+// Stop closes task admission, cancels the workspace lifecycle context and
+// waits for every task registered before the close. It is variadic so focused
+// tests can call Stop() while production callers can pass a bounded context.
+// A timeout never reopens the service; the closed instance remains available
+// for a later retry of Stop.
+func (s *Service) Stop(contexts ...context.Context) error {
+	if s == nil {
+		return nil
+	}
+	ctx := context.Background()
+	if len(contexts) > 0 && contexts[0] != nil {
+		ctx = contexts[0]
+	}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, serviceStopWait)
+		defer cancel()
+	}
+
+	s.taskMu.Lock()
+	s.tasksClosed = true
+	cancelLifecycle := s.lifecycleCancel
+	s.taskMu.Unlock()
+	if cancelLifecycle != nil {
+		cancelLifecycle()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.taskWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("停止工作目录服务超时: %w", ctx.Err())
+	}
+}
+
 func (s *Service) Startup(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	_, releaseTask, ok := s.beginTaskIfOpen()
+	if !ok {
+		return
+	}
+	defer releaseTask()
 	s.ctx = ctx
 	if s.exeDir == "" {
 		return
@@ -113,6 +268,9 @@ func (s *Service) Startup(ctx context.Context) {
 	if err != nil {
 		cfg = config.Default(s.dataDir)
 		s.emitLog("error", fmt.Sprintf("加载配置失败: %v", err))
+	}
+	if s.isStopped() {
+		return
 	}
 	s.mu.Lock()
 	s.config = cfg

--- a/internal/envsetup/service_actions.go
+++ b/internal/envsetup/service_actions.go
@@ -12,6 +12,9 @@ import (
 )
 
 func (s *Service) RetryStartupComponent(componentID string) StartupState {
+	releaseTask := s.beginTask()
+	defer releaseTask()
+
 	componentID = strings.TrimSpace(componentID)
 	s.emitLogWithFields("info", "用户触发重试组件", logFields{
 		Component: componentID,
@@ -47,6 +50,9 @@ func (s *Service) RetryStartupComponent(componentID string) StartupState {
 }
 
 func (s *Service) ReinstallStartupComponent(componentID string) (StartupState, error) {
+	releaseTask := s.beginTask()
+	defer releaseTask()
+
 	componentID = strings.TrimSpace(componentID)
 	s.emitLogWithFields("info", "用户触发重装组件", logFields{
 		Component: componentID,
@@ -91,6 +97,9 @@ func (s *Service) ReinstallStartupComponent(componentID string) (StartupState, e
 }
 
 func (s *Service) CancelStartupDownload(componentID string) StartupState {
+	releaseTask := s.beginTask()
+	defer releaseTask()
+
 	componentID = strings.TrimSpace(componentID)
 	s.emitLogWithFields("info", "用户触发取消下载", logFields{
 		Component: componentID,
@@ -189,6 +198,9 @@ func (s *Service) OpenExternalURL(rawURL string) error {
 }
 
 func (s *Service) ImportManualDownload(componentID string) StartupState {
+	releaseTask := s.beginTask()
+	defer releaseTask()
+
 	s.emitLogWithFields("info", "用户触发手动导入", logFields{
 		Component: componentID,
 		Action:    "manual_import",
@@ -236,6 +248,9 @@ func (s *Service) ImportManualDownload(componentID string) StartupState {
 }
 
 func (s *Service) PickCS2Path() StartupState {
+	releaseTask := s.beginTask()
+	defer releaseTask()
+
 	s.emitLogWithFields("info", "用户触发选择 CS2 路径", logFields{
 		Component: componentCS2,
 		Action:    "pick_path",

--- a/internal/envsetup/service_actions.go
+++ b/internal/envsetup/service_actions.go
@@ -12,7 +12,10 @@ import (
 )
 
 func (s *Service) RetryStartupComponent(componentID string) StartupState {
-	releaseTask := s.beginTask()
+	_, releaseTask, ok := s.beginTaskIfOpen()
+	if !ok {
+		return s.GetStartupState()
+	}
 	defer releaseTask()
 
 	componentID = strings.TrimSpace(componentID)
@@ -50,7 +53,10 @@ func (s *Service) RetryStartupComponent(componentID string) StartupState {
 }
 
 func (s *Service) ReinstallStartupComponent(componentID string) (StartupState, error) {
-	releaseTask := s.beginTask()
+	_, releaseTask, ok := s.beginTaskIfOpen()
+	if !ok {
+		return s.GetStartupState(), errServiceStopped
+	}
 	defer releaseTask()
 
 	componentID = strings.TrimSpace(componentID)
@@ -77,6 +83,9 @@ func (s *Service) ReinstallStartupComponent(componentID string) (StartupState, e
 	}
 	s.emitState()
 	defer func() {
+		if s.isStopped() {
+			return
+		}
 		s.mu.Lock()
 		s.state.Running = false
 		s.mu.Unlock()
@@ -97,7 +106,10 @@ func (s *Service) ReinstallStartupComponent(componentID string) (StartupState, e
 }
 
 func (s *Service) CancelStartupDownload(componentID string) StartupState {
-	releaseTask := s.beginTask()
+	_, releaseTask, ok := s.beginTaskIfOpen()
+	if !ok {
+		return s.GetStartupState()
+	}
 	defer releaseTask()
 
 	componentID = strings.TrimSpace(componentID)
@@ -155,6 +167,9 @@ func isCancelableDownloadComponent(componentID string) bool {
 }
 
 func (s *Service) OpenManualDownload(componentID string) error {
+	if s == nil || s.isStopped() {
+		return errServiceStopped
+	}
 	s.emitLogWithFields("info", "用户打开手动下载页", logFields{
 		Component: componentID,
 		Action:    "open_manual_download",
@@ -182,6 +197,9 @@ func (s *Service) OpenManualDownload(componentID string) error {
 }
 
 func (s *Service) OpenExternalURL(rawURL string) error {
+	if s == nil || s.isStopped() {
+		return errServiceStopped
+	}
 	url, ok := normalizeExternalOpenURL(rawURL)
 	if !ok {
 		return fmt.Errorf("无效外部链接")
@@ -198,7 +216,10 @@ func (s *Service) OpenExternalURL(rawURL string) error {
 }
 
 func (s *Service) ImportManualDownload(componentID string) StartupState {
-	releaseTask := s.beginTask()
+	_, releaseTask, ok := s.beginTaskIfOpen()
+	if !ok {
+		return s.GetStartupState()
+	}
 	defer releaseTask()
 
 	s.emitLogWithFields("info", "用户触发手动导入", logFields{
@@ -207,6 +228,9 @@ func (s *Service) ImportManualDownload(componentID string) StartupState {
 	})
 	path, err := s.pickManualFile(componentID)
 	if err != nil {
+		if s.isStopped() {
+			return s.GetStartupState()
+		}
 		s.failStep(componentID, err, "")
 		return s.GetStartupState()
 	}
@@ -215,6 +239,9 @@ func (s *Service) ImportManualDownload(componentID string) StartupState {
 			Component: componentID,
 			Action:    "manual_import",
 		})
+		return s.GetStartupState()
+	}
+	if s.isStopped() {
 		return s.GetStartupState()
 	}
 	s.emitLogWithFields("info", "手动导入文件已选择", logFields{
@@ -248,7 +275,10 @@ func (s *Service) ImportManualDownload(componentID string) StartupState {
 }
 
 func (s *Service) PickCS2Path() StartupState {
-	releaseTask := s.beginTask()
+	_, releaseTask, ok := s.beginTaskIfOpen()
+	if !ok {
+		return s.GetStartupState()
+	}
 	defer releaseTask()
 
 	s.emitLogWithFields("info", "用户触发选择 CS2 路径", logFields{
@@ -260,6 +290,9 @@ func (s *Service) PickCS2Path() StartupState {
 		CanCreateDirectories: false,
 	})
 	if err != nil {
+		if s.isStopped() {
+			return s.GetStartupState()
+		}
 		s.failStep(componentCS2, err, "")
 		return s.GetStartupState()
 	}
@@ -268,6 +301,9 @@ func (s *Service) PickCS2Path() StartupState {
 			Component: componentCS2,
 			Action:    "pick_path",
 		})
+		return s.GetStartupState()
+	}
+	if s.isStopped() {
 		return s.GetStartupState()
 	}
 	s.emitLogWithFields("info", "用户已选择 CS2 目录", logFields{
@@ -296,6 +332,9 @@ func (s *Service) PickCS2Path() StartupState {
 }
 
 func (s *Service) EnterMainApp() error {
+	if s == nil || s.isStopped() {
+		return errServiceStopped
+	}
 	s.emitLogWithFields("info", "用户尝试进入主页面", logFields{
 		Component: "startup",
 		Action:    "enter_main_app",

--- a/internal/envsetup/service_lifecycle_test.go
+++ b/internal/envsetup/service_lifecycle_test.go
@@ -1,0 +1,59 @@
+package envsetup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestServiceStopKeepsClosedBoundaryAfterTimeout(t *testing.T) {
+	svc := NewWithDataDir(t.TempDir(), t.TempDir(), "test")
+	_, release, ok := svc.beginTaskIfOpen()
+	if !ok {
+		t.Fatal("service task was not admitted")
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	err := svc.Stop(stopCtx)
+	cancel()
+	if err == nil {
+		t.Fatal("Stop unexpectedly succeeded while a task was held")
+	}
+	release()
+	if _, _, admitted := svc.beginTaskIfOpen(); admitted {
+		t.Fatal("timed-out service reopened task admission")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop error = %v, want deadline exceeded", err)
+	}
+	if err := svc.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop retry after task release: %v", err)
+	}
+}
+
+func TestServiceLifecycleContextCancelsDownloadGroups(t *testing.T) {
+	svc := NewWithDataDir(t.TempDir(), t.TempDir(), "test")
+	_, release, ok := svc.beginTaskIfOpen()
+	if !ok {
+		t.Fatal("service task was not admitted")
+	}
+	active, ctx, cancelCause := svc.beginDownloadGroup(componentFFmpeg)
+	if active == nil || ctx == nil {
+		t.Fatal("download group was not initialized")
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- svc.Stop(stopCtx) }()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("service stop did not cancel download context")
+	}
+	cancelCause(errDownloadFinished)
+	svc.endDownloadGroup(componentFFmpeg, active)
+	release()
+	if err := <-stopDone; err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}

--- a/internal/envsetup/service_logs_export.go
+++ b/internal/envsetup/service_logs_export.go
@@ -13,6 +13,12 @@ import (
 )
 
 func (s *Service) ExportStartupLogs() (string, error) {
+	_, releaseTask, ok := s.beginTaskIfOpen()
+	if !ok {
+		return "", errServiceStopped
+	}
+	defer releaseTask()
+
 	s.emitLogWithFields("info", "用户触发导出启动日志", logFields{
 		Component: "startup",
 		Action:    "export_logs",

--- a/internal/envsetup/service_startup.go
+++ b/internal/envsetup/service_startup.go
@@ -14,7 +14,10 @@ import (
 )
 
 func (s *Service) RunStartupChecks() StartupState {
-	releaseTask := s.beginTask()
+	_, releaseTask, ok := s.beginTaskIfOpen()
+	if !ok {
+		return s.GetStartupState()
+	}
 	defer releaseTask()
 
 	s.emitLogWithFields("info", "用户触发启动检查", logFields{
@@ -23,6 +26,10 @@ func (s *Service) RunStartupChecks() StartupState {
 	})
 
 	s.mu.Lock()
+	if s.isStopped() {
+		s.mu.Unlock()
+		return s.GetStartupState()
+	}
 	if s.state.Running {
 		state := s.state.clone()
 		s.mu.Unlock()
@@ -49,6 +56,9 @@ func (s *Service) RunStartupChecks() StartupState {
 	s.emitState()
 
 	defer func() {
+		if s.isStopped() {
+			return
+		}
 		s.mu.Lock()
 		s.state.Running = false
 		s.mu.Unlock()
@@ -62,6 +72,9 @@ func (s *Service) RunStartupChecks() StartupState {
 		return s.GetStartupState()
 	}
 	s.logStepDone("startup", "prepare_dirs", "ensure", "", 0, ensureDirsStart, nil)
+	if s.isStopped() {
+		return s.GetStartupState()
+	}
 
 	loadConfigStart := s.logStepStart("startup", "load_config", "read", "", 0, map[string]string{
 		"config_path": s.configPath,
@@ -81,6 +94,9 @@ func (s *Service) RunStartupChecks() StartupState {
 	s.config = cfg
 	s.mu.Unlock()
 	s.updateConfig(cfg)
+	if s.isStopped() {
+		return s.GetStartupState()
+	}
 
 	sourceDetectStart := s.logStepStart("source", "detect", "unified_source", "", 1, nil)
 	source, countryCode, message, detectErr := s.resolveStartupSource()
@@ -92,6 +108,9 @@ func (s *Service) RunStartupChecks() StartupState {
 	s.logStepDone("source", "detect", "unified_source", string(source), 1, sourceDetectStart, map[string]string{
 		"message": message,
 	})
+	if s.isStopped() {
+		return s.GetStartupState()
+	}
 
 	releaseFetchStart := s.logStepStart("source", "fetch_release", "request_unified", string(source), 1, map[string]string{
 		"api_url": endpoints.APIURLFor("app", string(source)),
@@ -101,6 +120,9 @@ func (s *Service) RunStartupChecks() StartupState {
 		s.logStepFail("source", "fetch_release", "request_unified", string(source), 1, releaseFetchStart, releaseErr, nil)
 	} else {
 		s.logStepDone("source", "fetch_release", "request_unified", string(source), 1, releaseFetchStart, nil)
+	}
+	if s.isStopped() {
+		return s.GetStartupState()
 	}
 
 	sourceMessage := message
@@ -142,6 +164,9 @@ func (s *Service) RunStartupChecks() StartupState {
 
 func (s *Service) ensureWorkDirs() error {
 	for _, dir := range []string{"temp", "hlae", "plugin", "ffmpeg", "updates", filepath.Join("demo", "raw")} {
+		if s.isStopped() {
+			return errServiceStopped
+		}
 		if err := os.MkdirAll(filepath.Join(s.dataDir, dir), 0755); err != nil {
 			return fmt.Errorf("创建目录失败 %s: %w", dir, err)
 		}
@@ -150,9 +175,15 @@ func (s *Service) ensureWorkDirs() error {
 }
 
 func (s *Service) resolveStartupSource() (DownloadSource, string, string, error) {
+	if s.isStopped() {
+		return "", "", "", errServiceStopped
+	}
 	resolved, err := resolveDownloadSource(nil)
 	if err != nil {
 		return "", "", "", err
+	}
+	if s.isStopped() {
+		return "", "", "", errServiceStopped
 	}
 	source := normalizeDownloadSource(string(resolved.Source))
 	countryCode := strings.ToUpper(strings.TrimSpace(resolved.CountryCode))
@@ -174,6 +205,9 @@ func normalizeDownloadSource(source string) DownloadSource {
 }
 
 func (s *Service) runTasksDefault(source DownloadSource) {
+	if s.isStopped() {
+		return
+	}
 	source = normalizeDownloadSource(string(source))
 	s.emitLogWithFields("info", "开始执行组件检查任务", logFields{
 		Component: "startup",
@@ -192,6 +226,9 @@ func (s *Service) runTasksDefault(source DownloadSource) {
 	s.emitState()
 
 	s.checkSelfUpdate(source)
+	if s.isStopped() {
+		return
+	}
 	s.mu.Lock()
 	selfUpdateAvailable := s.state.SelfUpdate.Available && s.state.SelfUpdate.Status == statusNeedsAction
 	s.mu.Unlock()

--- a/internal/envsetup/service_startup.go
+++ b/internal/envsetup/service_startup.go
@@ -14,6 +14,9 @@ import (
 )
 
 func (s *Service) RunStartupChecks() StartupState {
+	releaseTask := s.beginTask()
+	defer releaseTask()
+
 	s.emitLogWithFields("info", "用户触发启动检查", logFields{
 		Component: "startup",
 		Action:    "run_startup_checks",

--- a/internal/envsetup/service_state.go
+++ b/internal/envsetup/service_state.go
@@ -19,6 +19,9 @@ var (
 )
 
 func (s *Service) ensureReleaseSnapshot(source DownloadSource, force bool) error {
+	if s.isStopped() {
+		return errServiceStopped
+	}
 	source = normalizeDownloadSource(string(source))
 	s.mu.Lock()
 	cached := s.releaseSnapshot
@@ -30,6 +33,9 @@ func (s *Service) ensureReleaseSnapshot(source DownloadSource, force bool) error
 	snapshot, err := release.FetchUnifiedLatest(apiURL)
 	if err != nil {
 		return err
+	}
+	if s.isStopped() {
+		return errServiceStopped
 	}
 	validationErrors := append([]string(nil), snapshot.AdValidationErrors...)
 	mappedAds := mapReleaseAds(snapshot.Ads.Items)
@@ -66,6 +72,9 @@ func (s *Service) ensureReleaseSnapshot(source DownloadSource, force bool) error
 }
 
 func (s *Service) componentReleaseInfo(source DownloadSource, componentID string) (*release.Info, error) {
+	if s.isStopped() {
+		return nil, errServiceStopped
+	}
 	if err := s.ensureReleaseSnapshot(source, false); err != nil {
 		return nil, err
 	}
@@ -105,12 +114,18 @@ func (s *Service) resetTaskStepsLocked() {
 }
 
 func (s *Service) runComponent(componentID string, fn func() error) {
+	if s.isStopped() {
+		return
+	}
 	stepStarted := s.logStepStart(componentID, "check", "run_component", string(s.currentSource()), 0, nil)
 	s.updateStep(componentID, func(step *ComponentStatus) {
 		step.Status = statusChecking
 		step.Error = ""
 	})
 	if err := fn(); err != nil {
+		if s.isStopped() {
+			return
+		}
 		source := s.currentSource()
 		s.logStepFail(componentID, "check", "run_component", string(source), 0, stepStarted, err, nil)
 		s.failStep(componentID, err, endpoints.ManualURLFor(componentID, string(source)))
@@ -132,6 +147,9 @@ func (s *Service) currentCountryCode() string {
 }
 
 func (s *Service) setFatalError(err error) {
+	if err == nil || s.isStopped() {
+		return
+	}
 	s.mu.Lock()
 	s.state.FatalError = err.Error()
 	s.state.CanEnterMain = false
@@ -146,6 +164,9 @@ func (s *Service) setFatalError(err error) {
 }
 
 func (s *Service) failStep(componentID string, err error, manualURL string) {
+	if err == nil || s.isStopped() {
+		return
+	}
 	s.updateStep(componentID, func(step *ComponentStatus) {
 		step.Status = statusFailed
 		step.Error = err.Error()
@@ -165,6 +186,9 @@ func (s *Service) failStep(componentID string, err error, manualURL string) {
 }
 
 func (s *Service) updateStep(componentID string, mutate func(*ComponentStatus)) {
+	if s.isStopped() {
+		return
+	}
 	s.mu.Lock()
 	if step := s.findStepLocked(componentID); step != nil {
 		mutate(step)
@@ -174,6 +198,9 @@ func (s *Service) updateStep(componentID string, mutate func(*ComponentStatus)) 
 }
 
 func (s *Service) updateConfig(cfg *config.Config) {
+	if cfg == nil || s.isStopped() {
+		return
+	}
 	s.mu.Lock()
 	s.state.Config = *cfg
 	for i := range s.state.Steps {
@@ -202,8 +229,14 @@ func (s *Service) currentConfig() config.Config {
 }
 
 func (s *Service) persistConfig(mutate func(*config.Config) error) (*config.Config, error) {
+	if s.isStopped() {
+		return nil, errServiceStopped
+	}
 	s.configMu.Lock()
 	defer s.configMu.Unlock()
+	if s.isStopped() {
+		return nil, errServiceStopped
+	}
 
 	cfg, err := config.LoadOrCreate(s.configPath, s.dataDir)
 	if err != nil {
@@ -216,6 +249,9 @@ func (s *Service) persistConfig(mutate func(*config.Config) error) (*config.Conf
 	}
 	if err := config.Save(s.configPath, cfg); err != nil {
 		return nil, err
+	}
+	if s.isStopped() {
+		return nil, errServiceStopped
 	}
 	s.mu.Lock()
 	s.config = cfg
@@ -242,6 +278,9 @@ func (s *Service) updateManualURLsLocked(source DownloadSource) {
 }
 
 func (s *Service) refreshCanEnterMain() {
+	if s.isStopped() {
+		return
+	}
 	s.mu.Lock()
 	ready := s.state.FatalError == "" && !s.state.SelfUpdate.Available
 	warnings := make([]string, 0, 2)
@@ -281,6 +320,9 @@ func (s *Service) isFullyReadyLocked() bool {
 }
 
 func (s *Service) updatePhaseByReadiness() {
+	if s.isStopped() {
+		return
+	}
 	s.mu.Lock()
 	if s.state.CanEnterMain {
 		s.state.Phase = phaseReady
@@ -292,7 +334,7 @@ func (s *Service) updatePhaseByReadiness() {
 }
 
 func (s *Service) beginDownloadGroup(componentID string) (*activeDownloadCancel, context.Context, context.CancelCauseFunc) {
-	ctx, cancelCause := context.WithCancelCause(context.Background())
+	ctx, cancelCause := context.WithCancelCause(s.lifecycleContext())
 	active := &activeDownloadCancel{
 		cancel: func() { cancelCause(errDownloadCanceledByUser) },
 		ctx:    ctx,
@@ -342,6 +384,9 @@ func (s *Service) downloadFile(componentID string, url string, targetPath string
 		err = download.ErrCanceled
 	}
 	s.endDownloadGroup(componentID, active)
+	if err == nil && s.isStopped() {
+		err = errServiceStopped
+	}
 
 	if err != nil {
 		s.logStepFail(componentID, "download", "download_asset", string(s.currentSource()), 0, started, err, map[string]string{


### PR DESCRIPTION
## 概述

本 PR 完整实施了后端架构优化第一阶段 **Step 01：工作目录生命周期与后台任务生命周期**（包含 Step 01-A 与 Step 01-B），彻底解决审查缺陷 **B1**，确保工作目录切换、删除与全部使用者互斥，旧任务不能污染新工作目录。

## 主要变更

### 1. 私有 workspaceSession 实例所有权与生命周期
- 新增私有 `workspaceSession`，不可变持有选定工作目录的 `root`、`generation`、`envsetup.Service` 实例与生命周期 `context`。
- 提供 `beginTask()` 任务登记、`closeIfIdle()` 非取消安全关闭、`close()` 实例取消与超时等待机制。任务在启动前登记，彻底避免 `taskWG` 的 `Wait` 与 `Add` 竞态。

### 2. 生命周期排他门禁与流程加固
- `SetWorkspaceDir` 与 `ResetWorkspace` 统一接入 `beginWorkspaceTransition()` 生命周期门禁，原子完成互斥资格获取。
- 活跃制作会话、文件读写、启动检查或后台任务未完成时，重置请求以明确错误拒绝，不删除文件、不关闭游戏、不释放备份。
- `Shutdown` 纳入工作目录后台任务退出流程：先关闭新任务准入，等待制作环境恢复，再取消并等待 workspace session 任务全部退出，最后关闭 WebSocket 服务。

### 3. 异步任务与状态发射隔离
- `envsetup.Service` 纳入实例级停止与任务计数生命周期（`taskMu`/`activeTasks`/`taskWG`/`tasksClosed`/`lifecycleCtx`）。
- 将 FFmpeg 能力探测等后台任务纳入任务门禁与生命周期 context 绑定；`Service.Stop()` 时立即中断探测。
- `emitState`、`emitProgress`、`appendLogEntry`、`persistConfig` 等关键写入与事件发射全面增加 `isStopped()` 拦截，防止已停止实例向磁盘写文件或污染前端状态。

### 4. 失败状态隔离与可重试机制
- 目录删除或注册表清理失败时，通过 `detachWorkspaceForReset` 立即卸载旧服务并记录 `pendingReset`，旧服务无法再写文件。
- `pendingReset` 状态下拒绝 `SetWorkspaceDir` 安装新目录；再次调用 `ResetWorkspace` 可恢复并重试清理剩余资源。

### 5. 内存快照与产物去重清理
- 重置成功后通过 `clearProduceWorkspaceState` 清除与旧工作目录关联的 `takeFiles`、`historyItems` 等内存索引与去重缓存。
- 立即发射空的 `ProduceTakeFileSnapshot` 与 `ProduceHistorySnapshot` 事件，防止新工作目录生成继续引用旧历史。

### 6. 跨 Workspace 路径保护
- 针对 `loadConfig`、`updateConfig`、Demo 导入（完美/5E/本地）、`RepairGameInfo`、日志与视频导出等关键入口增加工作目录租约保护，统一使用稳定快照路径，避免在 I/O 过程中工作目录漂移。

## 测试与验证

- `go test ./... -count=1`（全部通过）
- `go test -race ./internal/app ./internal/envsetup`（全部通过）
- `go vet ./...`（全部通过）
- Windows 交叉编译：`GOOS=windows GOARCH=amd64 go build ./...`（通过）
- `git diff --check`（无格式与空白问题）
- 前端契约与构建：`cd frontend && npm test && npm run build`（全部通过）
