### PR TITLE
refactor(config): share workspace config store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ CS2 Demo 导入、片段选择、自动录制与后期拼接的 Windows 桌面�
 | `internal/app/` | Wails 暴露边界、业务流程编排、制作会话与文件使用权管理 |
 | `internal/appdata/` | 工作目录校验、Windows 注册表读写、旧数据清理 |
 | `internal/envsetup/` | 启动状态机、自更新、组件检查安装、启动日志导出 |
-| `internal/config/` | 配置读写、默认值、兼容处理与路径规范化 |
+| `internal/config/` | 配置读写、默认值、兼容处理、路径规范化与工作目录级 `Store` 事务 |
 | `internal/release/`、`internal/endpoints/`、`internal/download/` | Release 快照、下载地址策略、下载与解压 |
 | `internal/demo/` | Demo 解析、击杀事实、整局 POV 计划 |
 | `internal/wanmei/`、`internal/fivee/` | 对战平台查询与 Demo 下载 |
@@ -67,6 +67,7 @@ CS2 Demo 导入、片段选择、自动录制与后期拼接的 Windows 桌面�
 - `<dataDir>` 是已选工作目录，配置、组件、Demo、输出、临时文件和日志均以此为根；不可再假设 Windows 固定使用 `%LOCALAPPDATA%/CS2 Highlight Tool`。非 Windows 开发回退见 `fallbackDataDirForDev`。
 - `<exeDir>` 与 `<dataDir>` 必须区分：前者定位程序和自更新替换目标。`ResetWorkspace` 会删除当前整个工作目录并清除注册表记录，不等同于清理 Demo 或 outputs。
 - `internal/app/workspace_session.go` 的私有工作目录实例固定 root、generation、envsetup service 与生命周期 context；后台任务须先登记，Reset/Shutdown 先关闭准入并按既有制作/文件占用规则取消、等待或拒绝，旧实例不得在新工作目录提交后写文件或发射启动事件。
+- 每个工作目录实例只创建一个 `internal/config.Store`，由 App 与 `envsetup.Service` 共享；Store 锁覆盖最新配置读取、默认/兼容归一化、mutate 和原子保存，网络、探测与事件不得进入 Store 锁。工作目录关闭时 Store 永久关闭，旧实例不得重新落盘；锁顺序保持为工作目录准入 → Store，事件在 Store 解锁后发射。
 - `GetStartupState`、`RunStartupChecks`、`RetryStartupComponent`、`ReinstallStartupComponent`、`CancelStartupDownload`、`OpenManualDownload`、`ImportManualDownload`、`PickCS2Path`、`EnterMainApp`、`OpenExternalURL`、`ExportStartupLogs` 的入口为 `internal/app/app_startup.go`。
 - 状态源为 `GetStartupState` 和 `startup_state_changed`，模型见 `internal/envsetup/state.go`。`mode` 为 `workspace_init|startup|main`；`phase` 为 `detecting_source|waiting_source|running_tasks|ready`；二者不可混用。
 - 组件 ID：`hlae`、`plugin`、`ffmpeg`、`cs2`。组件/启动状态：`pending`、`checking`、`downloading`、`installing`、`ready`、`warning`、`failed`、`needs_action`。

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -6,7 +6,7 @@
 
 - `app/` 承担 Wails 边界和跨模块编排，公开请求/响应在此定义；不要让低层包依赖 UI。
 - 启动状态模型与通知入口：`envsetup/state.go`、`envsetup/events.go`；检查/动作/状态逻辑按 `service_*.go` 分工。
-- 配置默认值、归一化和兼容处理集中在 `config/config.go`；应用层设置映射在 `app/clip_settings.go`。
+- 配置默认值、归一化和兼容处理集中在 `config/config.go`；同一工作目录的读改写事务由 `config.Store` 统一串行化并由 App 注入 `envsetup.Service`；应用层设置映射在 `app/clip_settings.go`。
 - Demo 事实与整局 POV 解析在 `demo/`，片段归一化与生成编排在 `app/plugin_generate.go`，插件命令构建在 `clipsjson/`。
 - 会话、清理和文件占用分别从 `app/produce_session.go`、`app/produce_cleanup.go`、`app/work_activity.go` 查起；WebSocket 状态与协议在 `producews/`。
 - Windows 专用行为与其他平台实现通过现有平台文件分开维护；非 Windows 测试不能替代 Windows 运行验证。
@@ -22,7 +22,7 @@
 
 ## 并发、进程与收尾
 
-- `Service.state`、`Service.logs`、`Service.config` 遵循现有 `mu/configMu` 锁策略；应用 service 的访问遵循 `serviceMu`。
+- `Service.state`、`Service.logs`、已提交的 `Service.config` 快照由 `Service.mu` 保护；配置文件的最新读取、归一化、mutate 和保存只走工作目录共享的 `config.Store`，不再为 App/Service 各自维护文件锁。工作目录准入后再进入 Store，保存成功后才更新 Service 快照，事件必须在 Store 解锁后发射；应用 service 的访问遵循 `serviceMu`。
 - `app/workspace_session.go` 的私有 `workspaceSession` 持有不可变 root/generation/service 与生命周期 context；任务须在启动前登记。切换/退出先关闭准入，再取消并等待，不得在 service/state 锁内等待、做 I/O 或发射事件。`envsetup.Service` 的 `BindLifecycleContext`、`CloseIfIdle`、`Stop` 仅由 App 的 session 生命周期调用，旧实例关闭后不得重新接收任务。
 - 避免锁内执行阻塞 I/O、网络或 runtime 事件发射，不引入锁顺序反转。启动状态更新后通过 `emitState()` 通知前端；制作事件复用现有队列。
 - `GetWorkActivity` 的前端禁用策略不代替后端互斥；文件读写/导出/清理复用现有文件使用权机制。

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,13 +27,11 @@ type App struct {
 
 	serviceMu sync.Mutex
 	// workspace is the immutable identity used by new operations. service and
-	// dataDir remain mirrors for compatibility with existing App consumers.
+	// dataDir/configStore remain mirrors for compatibility with existing App
+	// consumers and are always replaced together with the workspace identity.
 	workspace           *workspaceSession
 	workspaceGeneration uint64
-	// configMu serializes App-level read-modify-write operations on config.json.
-	// It intentionally does not cover external work; callers load or persist
-	// through the helpers below and release the lock before doing other I/O.
-	configMu sync.Mutex
+	configStore         *config.Store
 
 	produceStateMu sync.Mutex
 	produceState   produceSessionState
@@ -114,7 +112,8 @@ func (a *App) initWorkspaceLocked() {
 			_ = appdata.DeleteDataDirFromRegistry()
 			return
 		}
-		svc := envsetup.NewWithDataDir(a.exeDir, stored, a.version)
+		store := config.NewStore(filepath.Join(stored, "config.json"), stored)
+		svc := envsetup.NewWithDataDirAndStore(a.exeDir, stored, a.version, store)
 		a.serviceMu.Lock()
 		a.installWorkspaceLocked(stored, svc)
 		a.serviceMu.Unlock()
@@ -126,7 +125,8 @@ func (a *App) initWorkspaceLocked() {
 	fallback := fallbackDataDirForDev(a.exeDir)
 	if fallback != "" {
 		_ = os.MkdirAll(fallback, 0o755)
-		svc := envsetup.NewWithDataDir(a.exeDir, fallback, a.version)
+		store := config.NewStore(filepath.Join(fallback, "config.json"), fallback)
+		svc := envsetup.NewWithDataDirAndStore(a.exeDir, fallback, a.version, store)
 		a.serviceMu.Lock()
 		a.installWorkspaceLocked(fallback, svc)
 		a.serviceMu.Unlock()
@@ -153,7 +153,11 @@ func (a *App) seedFirstInstallChangelogAt(dataDir string, version string) {
 	if a == nil || dataDir == "" || version == "" {
 		return
 	}
-	_, _ = config.EnsureFirstInstallChangelogSeed(filepath.Join(dataDir, "config.json"), dataDir, version)
+	store := a.configStoreForWorkspace(dataDir, nil)
+	if store == nil {
+		return
+	}
+	_, _ = store.EnsureFirstInstallChangelogSeed(version)
 }
 
 // isUsableDataDir 用于"已初始化"分支：目录存在 + 字符白名单 + 非磁盘根 + 长度合规。
@@ -298,10 +302,12 @@ func (a *App) loadConfig() (*config.Config, error) {
 		return nil, err
 	}
 	defer release()
-
-	a.configMu.Lock()
-	defer a.configMu.Unlock()
-	return config.LoadOrCreate(filepath.Join(dataDir, "config.json"), dataDir)
+	snapshot := a.workspaceSnapshot()
+	store := a.configStoreForWorkspace(dataDir, snapshot.service)
+	if store == nil {
+		return nil, fmt.Errorf("配置存储未初始化")
+	}
+	return store.Snapshot()
 }
 
 func (a *App) updateConfig(mutate func(*config.Config) error) (*config.Config, error) {
@@ -310,22 +316,17 @@ func (a *App) updateConfig(mutate func(*config.Config) error) (*config.Config, e
 		return nil, err
 	}
 	defer release()
-
-	a.configMu.Lock()
-	defer a.configMu.Unlock()
-
-	path := filepath.Join(dataDir, "config.json")
-	cfg, err := config.LoadOrCreate(path, dataDir)
+	snapshot := a.workspaceSnapshot()
+	store := a.configStoreForWorkspace(dataDir, snapshot.service)
+	if store == nil {
+		return nil, fmt.Errorf("配置存储未初始化")
+	}
+	cfg, revision, err := store.UpdateWithRevision(mutate)
 	if err != nil {
 		return nil, err
 	}
-	if mutate != nil {
-		if err := mutate(cfg); err != nil {
-			return nil, err
-		}
-	}
-	if err := config.Save(path, cfg); err != nil {
-		return nil, err
+	if snapshot.service != nil {
+		snapshot.service.ApplyConfigSnapshot(cfg, revision)
 	}
 	return cfg, nil
 }

--- a/internal/app/app_changelog.go
+++ b/internal/app/app_changelog.go
@@ -24,8 +24,8 @@ type PendingChangelog struct {
 //   - LastChangelogVersion != 当前版本（含老用户首次升级到带本功能版本的情况，此时为空字符串）→ 尝试读 embed 文件
 //   - embed 文件缺失 → 不展示（容错跳过，不写回 LastChangelogVersion）
 //
-// 全新安装的"首装静默"语义在 App 初始化阶段通过 config.EnsureFirstInstallChangelogSeed 实现，
-// 这里不再区分"首装"与"老用户"。
+// 全新安装的"首装静默"语义在 App 初始化阶段通过工作目录共享 Store
+// 的 EnsureFirstInstallChangelogSeed 实现，这里不再区分"首装"与"老用户"。
 func (a *App) GetPendingChangelog() (*PendingChangelog, error) {
 	currentVersion := strings.TrimSpace(a.version)
 	if currentVersion == "" {

--- a/internal/app/app_config_test.go
+++ b/internal/app/app_config_test.go
@@ -2,10 +2,12 @@ package app
 
 import (
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"cs2-highlight-tool-v2/internal/config"
+	"cs2-highlight-tool-v2/internal/envsetup"
 )
 
 func TestAppUpdateConfigSerializesReadModifyWrite(t *testing.T) {
@@ -13,6 +15,9 @@ func TestAppUpdateConfigSerializesReadModifyWrite(t *testing.T) {
 	app := &App{exeDir: exeDir}
 	firstEntered := make(chan struct{})
 	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFirst) }) }
+	defer release()
 	firstErr := make(chan error, 1)
 	go func() {
 		_, err := app.updateConfig(func(cfg *config.Config) error {
@@ -23,7 +28,11 @@ func TestAppUpdateConfigSerializesReadModifyWrite(t *testing.T) {
 		})
 		firstErr <- err
 	}()
-	<-firstEntered
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first config update did not enter mutate")
+	}
 
 	secondDone := make(chan struct{})
 	secondErr := make(chan error, 1)
@@ -37,10 +46,10 @@ func TestAppUpdateConfigSerializesReadModifyWrite(t *testing.T) {
 	}()
 	select {
 	case <-secondDone:
-		t.Fatal("second config update ran while first update held configMu")
+		t.Fatal("second config update ran while first Store transaction was held")
 	case <-time.After(50 * time.Millisecond):
 	}
-	close(releaseFirst)
+	release()
 
 	if err := <-firstErr; err != nil {
 		t.Fatalf("first update: %v", err)
@@ -54,5 +63,126 @@ func TestAppUpdateConfigSerializesReadModifyWrite(t *testing.T) {
 	}
 	if cfg.LastChangelogVersion != "first" || cfg.FiveEPlayerName != "second" {
 		t.Fatalf("concurrent updates lost data: %+v", cfg)
+	}
+}
+
+func TestAppAndServiceShareWorkspaceConfigStore(t *testing.T) {
+	exeDir := t.TempDir()
+	dataDir := t.TempDir()
+	store := config.NewStore(filepath.Join(dataDir, "config.json"), dataDir)
+	svc := envsetup.NewWithDataDirAndStore(exeDir, dataDir, "test", store)
+	app := &App{exeDir: exeDir, dataDir: dataDir, service: svc}
+	app.ensureWorkspaceSession()
+
+	snapshot := app.workspaceSnapshot()
+	if snapshot.store != store || svc.ConfigStore() != store {
+		t.Fatalf("workspace did not retain one Store instance: app=%p service=%p want=%p", snapshot.store, svc.ConfigStore(), store)
+	}
+	if _, err := app.updateConfig(func(cfg *config.Config) error {
+		cfg.RecordQuality = "ultra"
+		return nil
+	}); err != nil {
+		t.Fatalf("app update: %v", err)
+	}
+	if _, err := store.Update(func(cfg *config.Config) error {
+		cfg.FFmpegDetectedPreset = "n1_h264"
+		cfg.FFmpegDetectedEncoders = []string{"libx264"}
+		return nil
+	}); err != nil {
+		t.Fatalf("service update: %v", err)
+	}
+	cfg, err := app.loadConfig()
+	if err != nil {
+		t.Fatalf("load final config: %v", err)
+	}
+	if cfg.RecordQuality != "ultra" || cfg.FFmpegDetectedPreset != "n1_h264" || len(cfg.FFmpegDetectedEncoders) != 1 {
+		t.Fatalf("shared Store lost cross-layer fields: %+v", cfg)
+	}
+}
+
+func TestAppAndServiceConfigTransactionsPreserveBothFieldsInEitherOrder(t *testing.T) {
+	for _, serviceFirst := range []bool{true, false} {
+		t.Run(map[bool]string{true: "service-first", false: "app-first"}[serviceFirst], func(t *testing.T) {
+			exeDir := t.TempDir()
+			dataDir := t.TempDir()
+			store := config.NewStore(filepath.Join(dataDir, "config.json"), dataDir)
+			svc := envsetup.NewWithDataDirAndStore(exeDir, dataDir, "test", store)
+			app := &App{exeDir: exeDir, dataDir: dataDir, service: svc}
+			app.ensureWorkspaceSession()
+
+			firstEntered := make(chan struct{})
+			secondEntered := make(chan struct{})
+			releaseFirst := make(chan struct{})
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(func() { close(releaseFirst) }) }
+			defer release()
+			firstErr := make(chan error, 1)
+			secondErr := make(chan error, 1)
+			if serviceFirst {
+				go func() {
+					_, err := store.Update(func(cfg *config.Config) error {
+						cfg.FFmpegDetectedPreset = "n1_h264"
+						close(firstEntered)
+						<-releaseFirst
+						return nil
+					})
+					firstErr <- err
+				}()
+			} else {
+				go func() {
+					_, err := app.updateConfig(func(cfg *config.Config) error {
+						cfg.RecordQuality = "ultra"
+						close(firstEntered)
+						<-releaseFirst
+						return nil
+					})
+					firstErr <- err
+				}()
+			}
+			select {
+			case <-firstEntered:
+			case <-time.After(time.Second):
+				t.Fatal("first transaction did not enter mutate")
+			}
+
+			if serviceFirst {
+				go func() {
+					_, err := app.updateConfig(func(cfg *config.Config) error {
+						close(secondEntered)
+						cfg.RecordQuality = "ultra"
+						return nil
+					})
+					secondErr <- err
+				}()
+			} else {
+				go func() {
+					_, err := store.Update(func(cfg *config.Config) error {
+						close(secondEntered)
+						cfg.FFmpegDetectedPreset = "n1_h264"
+						return nil
+					})
+					secondErr <- err
+				}()
+			}
+			select {
+			case <-secondEntered:
+				t.Fatal("second cross-layer transaction entered before first committed")
+			case <-time.After(50 * time.Millisecond):
+			}
+			release()
+			if err := <-firstErr; err != nil {
+				t.Fatalf("first transaction: %v", err)
+			}
+			if err := <-secondErr; err != nil {
+				t.Fatalf("second transaction: %v", err)
+			}
+			cfg, err := store.Snapshot()
+			if err != nil {
+				t.Fatalf("final snapshot: %v", err)
+			}
+			if cfg.RecordQuality != "ultra" || cfg.FFmpegDetectedPreset != "n1_h264" {
+				t.Fatalf("cross-layer transaction lost a field: %+v", cfg)
+			}
+		})
 	}
 }

--- a/internal/app/app_workspace.go
+++ b/internal/app/app_workspace.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"cs2-highlight-tool-v2/internal/appdata"
+	"cs2-highlight-tool-v2/internal/config"
 	"cs2-highlight-tool-v2/internal/envsetup"
 
 	wruntime "github.com/wailsapp/wails/v2/pkg/runtime"
@@ -118,7 +119,8 @@ func (a *App) SetWorkspaceDir(path string) error {
 
 	// 构造 service 并启动。先提交不可变 workspace session，再登记所有
 	// 即将启动的后台任务；整个过程仍在生命周期排他资格内。
-	svc := envsetup.NewWithDataDir(a.exeDir, path, a.version)
+	store := config.NewStore(filepath.Join(path, "config.json"), path)
+	svc := envsetup.NewWithDataDirAndStore(a.exeDir, path, a.version, store)
 	a.serviceMu.Lock()
 	session := a.installWorkspaceLocked(path, svc)
 	a.serviceMu.Unlock()
@@ -210,6 +212,7 @@ func (a *App) ResetWorkspace() error {
 	a.serviceMu.Lock()
 	a.service = nil
 	a.dataDir = ""
+	a.configStore = nil
 	a.workspace = nil
 	a.workspaceGeneration++
 	a.workspaceResetPendingPath = ""
@@ -231,6 +234,7 @@ func (a *App) detachWorkspaceForReset(dataDir string) {
 	a.serviceMu.Lock()
 	a.service = nil
 	a.dataDir = ""
+	a.configStore = nil
 	a.workspace = nil
 	a.workspaceGeneration++
 	a.workspaceResetPendingPath = dataDir

--- a/internal/app/workspace_session.go
+++ b/internal/app/workspace_session.go
@@ -3,9 +3,11 @@ package app
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sync"
 	"time"
 
+	"cs2-highlight-tool-v2/internal/config"
 	"cs2-highlight-tool-v2/internal/envsetup"
 )
 
@@ -19,6 +21,7 @@ type workspaceSession struct {
 	root       string
 	generation uint64
 	service    *envsetup.Service
+	store      *config.Store
 	ctx        context.Context
 	cancel     context.CancelFunc
 
@@ -34,6 +37,7 @@ func newWorkspaceSession(root string, generation uint64, service *envsetup.Servi
 		root:       root,
 		generation: generation,
 		service:    service,
+		store:      serviceStore(service),
 		ctx:        ctx,
 		cancel:     cancel,
 	}
@@ -41,6 +45,13 @@ func newWorkspaceSession(root string, generation uint64, service *envsetup.Servi
 		service.BindLifecycleContext(ctx)
 	}
 	return session
+}
+
+func serviceStore(service *envsetup.Service) *config.Store {
+	if service == nil {
+		return nil
+	}
+	return service.ConfigStore()
 }
 
 func (s *workspaceSession) isClosed() bool {
@@ -169,6 +180,7 @@ func (s *workspaceSession) close(ctx context.Context) error {
 type workspaceSnapshot struct {
 	session       *workspaceSession
 	service       *envsetup.Service
+	store         *config.Store
 	root          string
 	generation    uint64
 	exeDir        string
@@ -187,6 +199,7 @@ func (a *App) workspaceSnapshot() workspaceSnapshot {
 	snapshot := workspaceSnapshot{
 		session:       a.workspace,
 		service:       a.service,
+		store:         a.configStore,
 		root:          a.dataDir,
 		generation:    a.workspaceGeneration,
 		exeDir:        a.exeDir,
@@ -197,7 +210,11 @@ func (a *App) workspaceSnapshot() workspaceSnapshot {
 	if snapshot.session != nil {
 		snapshot.root = snapshot.session.root
 		snapshot.service = snapshot.session.service
+		snapshot.store = snapshot.session.store
 		snapshot.generation = snapshot.session.generation
+	}
+	if snapshot.store == nil {
+		snapshot.store = serviceStore(snapshot.service)
 	}
 	return snapshot
 }
@@ -214,6 +231,7 @@ func (a *App) ensureWorkspaceSessionLocked() *workspaceSession {
 	}
 	a.workspaceGeneration++
 	a.workspace = newWorkspaceSession(a.dataDir, a.workspaceGeneration, a.service)
+	a.configStore = a.workspace.store
 	return a.workspace
 }
 
@@ -235,10 +253,59 @@ func (a *App) installWorkspaceLocked(root string, service *envsetup.Service) *wo
 	a.workspace = session
 	a.dataDir = root
 	a.service = service
+	a.configStore = session.store
+	if a.configStore == nil && root != "" {
+		a.configStore = config.NewStore(filepath.Join(root, "config.json"), root)
+	}
 	a.workspaceResetPendingPath = ""
 	a.workspaceResetRegistryPending = false
 	a.workspaceResetCompleted = false
 	return session
+}
+
+// configStoreForWorkspace returns the store fixed to one workspace. Production
+// callers use the store injected into Service; manually constructed test/dev
+// Apps lazily create one mirror so their read-modify-write operations still
+// serialize. A live workspace never permits a different root to replace its
+// store.
+func (a *App) configStoreForWorkspace(dataDir string, service *envsetup.Service) *config.Store {
+	if a == nil || dataDir == "" {
+		return nil
+	}
+	root := filepath.Clean(dataDir)
+	if service != nil {
+		store := serviceStore(service)
+		if store == nil {
+			return nil
+		}
+		if store.DataRoot() != "" && filepath.Clean(store.DataRoot()) != root {
+			return nil
+		}
+		a.serviceMu.Lock()
+		a.configStore = store
+		a.serviceMu.Unlock()
+		return store
+	}
+
+	a.serviceMu.Lock()
+	defer a.serviceMu.Unlock()
+	if a.workspace != nil {
+		if filepath.Clean(a.workspace.root) != root || a.workspace.isClosed() {
+			return nil
+		}
+		if a.workspace.store != nil {
+			return a.workspace.store
+		}
+	}
+	if a.configStore != nil {
+		if a.configStore.DataRoot() == "" || filepath.Clean(a.configStore.DataRoot()) == root {
+			return a.configStore
+		}
+		return nil
+	}
+	store := config.NewStore(filepath.Join(root, "config.json"), root)
+	a.configStore = store
+	return store
 }
 
 // clearProduceWorkspaceState drops in-memory take/history indexes that belong

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,10 @@ func Default(dataDir string) *Config {
 // 必须在任何 LoadOrCreate 调用之前调用，否则会失去"首装"判定语义。
 // 返回 seeded=true 仅用于调用方日志或测试。
 func EnsureFirstInstallChangelogSeed(path, dataDir, currentVersion string) (bool, error) {
+	return ensureFirstInstallChangelogSeed(path, dataDir, currentVersion, Save)
+}
+
+func ensureFirstInstallChangelogSeed(path, dataDir, currentVersion string, save func(string, *Config) error) (bool, error) {
 	currentVersion = strings.TrimSpace(currentVersion)
 	if currentVersion == "" {
 		return false, nil
@@ -131,18 +135,28 @@ func EnsureFirstInstallChangelogSeed(path, dataDir, currentVersion string) (bool
 	}
 	cfg := Default(dataDir)
 	cfg.LastChangelogVersion = currentVersion
-	if err := Save(path, cfg); err != nil {
+	if save == nil {
+		save = Save
+	}
+	if err := save(path, cfg); err != nil {
 		return false, err
 	}
 	return true, nil
 }
 
 func LoadOrCreate(path, dataDir string) (*Config, error) {
+	return loadOrCreate(path, dataDir, Save)
+}
+
+func loadOrCreate(path, dataDir string, save func(string, *Config) error) (*Config, error) {
+	if save == nil {
+		save = Save
+	}
 	cfg := Default(dataDir)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if err := Save(path, cfg); err != nil {
+			if err := save(path, cfg); err != nil {
 				return nil, err
 			}
 			return cfg, nil
@@ -173,7 +187,7 @@ func LoadOrCreate(path, dataDir string) (*Config, error) {
 	}
 	ApplyDefaults(cfg, dataDir)
 	if configNeedsSave(data, &before, cfg) {
-		if err := Save(path, cfg); err != nil {
+		if err := save(path, cfg); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -1,0 +1,202 @@
+package config
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+)
+
+// ErrStoreClosed is returned when a workspace has already stopped admitting
+// configuration reads or writes. A closed store is never reopened; the
+// workspace lifecycle owns that boundary.
+var ErrStoreClosed = errors.New("配置存储已关闭")
+
+// Store serializes the complete config read/normalize/mutate/save transaction
+// for one immutable workspace. It deliberately knows nothing about App,
+// Wails, or envsetup; callers decide what to do with a committed snapshot
+// after this lock has been released.
+//
+// Store does not cache Config values. Each Snapshot/Update observes the file
+// through the existing LoadOrCreate compatibility path, so external edits
+// retain the historical read semantics while all in-process writers share one
+// lock.
+type Store struct {
+	path     string
+	dataRoot string
+
+	mu       sync.Mutex
+	closed   atomic.Bool
+	revision uint64
+
+	// saveFn is intentionally package-private so config tests can inject a
+	// failed save without weakening the production Save implementation.
+	saveFn func(string, *Config) error
+}
+
+// NewStore binds a store to one config path and data root. The paths are
+// normalized once and never follow a later App dataDir change.
+func NewStore(path, dataRoot string) *Store {
+	if path == "" && dataRoot != "" {
+		path = filepath.Join(dataRoot, "config.json")
+	}
+	if path != "" {
+		path = filepath.Clean(path)
+	}
+	if dataRoot != "" {
+		dataRoot = filepath.Clean(dataRoot)
+	}
+	return &Store{path: path, dataRoot: dataRoot}
+}
+
+// Path returns the immutable config path bound at construction time.
+func (s *Store) Path() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
+}
+
+// DataRoot returns the immutable workspace root bound at construction time.
+func (s *Store) DataRoot() string {
+	if s == nil {
+		return ""
+	}
+	return s.dataRoot
+}
+
+// IsClosed reports whether the workspace lifecycle has closed this store.
+func (s *Store) IsClosed() bool {
+	if s == nil {
+		return true
+	}
+	return s.closed.Load()
+}
+
+// Close permanently closes the store. It is idempotent and does not remove
+// or otherwise mutate the config file.
+func (s *Store) Close() {
+	if s == nil {
+		return
+	}
+	s.closed.Store(true)
+}
+
+// Snapshot loads and normalizes the latest config under the store lock and
+// returns a deep-enough copy that callers may freely mutate.
+func (s *Store) Snapshot() (*Config, error) {
+	cfg, _, err := s.SnapshotWithRevision()
+	return cfg, err
+}
+
+// SnapshotWithRevision is Snapshot plus the monotonically increasing commit
+// observation used by envsetup to reject an older post-commit publication.
+func (s *Store) SnapshotWithRevision() (*Config, uint64, error) {
+	if s == nil {
+		return nil, 0, ErrStoreClosed
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed.Load() {
+		return nil, s.revision, ErrStoreClosed
+	}
+	cfg, err := s.loadOrCreateLocked()
+	if err != nil {
+		return nil, s.revision, err
+	}
+	s.revision++
+	return cloneConfig(cfg), s.revision, nil
+}
+
+// Update executes the complete read/normalize/mutate/save transaction and
+// returns the committed snapshot. The mutate callback runs while the store is
+// locked and must not perform blocking I/O, call this Store again, or emit
+// events.
+func (s *Store) Update(mutate func(*Config) error) (*Config, error) {
+	cfg, _, err := s.UpdateWithRevision(mutate)
+	return cfg, err
+}
+
+// UpdateWithRevision is Update plus a commit observation for consumers that
+// keep a derived, in-memory snapshot. The revision is advanced only after a
+// successful Save, so failed mutations and failed saves publish nothing.
+func (s *Store) UpdateWithRevision(mutate func(*Config) error) (*Config, uint64, error) {
+	if s == nil {
+		return nil, 0, ErrStoreClosed
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed.Load() {
+		return nil, s.revision, ErrStoreClosed
+	}
+	cfg, err := s.loadOrCreateLocked()
+	if err != nil {
+		return nil, s.revision, err
+	}
+	if mutate != nil {
+		if err := mutate(cfg); err != nil {
+			return nil, s.revision, err
+		}
+	}
+	if s.closed.Load() {
+		return nil, s.revision, ErrStoreClosed
+	}
+	if err := s.saveLocked(cfg); err != nil {
+		return nil, s.revision, err
+	}
+	s.revision++
+	return cloneConfig(cfg), s.revision, nil
+}
+
+// EnsureFirstInstallChangelogSeed preserves the first-install ordering rule
+// while sharing the same transaction lock as all subsequent config access.
+func (s *Store) EnsureFirstInstallChangelogSeed(currentVersion string) (bool, error) {
+	if s == nil {
+		return false, ErrStoreClosed
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed.Load() {
+		return false, ErrStoreClosed
+	}
+	seeded, err := ensureFirstInstallChangelogSeed(s.path, s.dataRoot, currentVersion, s.saveAtLocked)
+	if err == nil && seeded {
+		s.revision++
+	}
+	return seeded, err
+}
+
+func (s *Store) saveLocked(cfg *Config) error {
+	return s.saveAtLocked(s.path, cfg)
+}
+
+func (s *Store) saveAtLocked(path string, cfg *Config) error {
+	if s.saveFn != nil {
+		return s.saveFn(path, cfg)
+	}
+	return Save(path, cfg)
+}
+
+func (s *Store) loadOrCreateLocked() (*Config, error) {
+	return loadOrCreate(s.path, s.dataRoot, s.saveAtLocked)
+}
+
+func cloneConfig(cfg *Config) *Config {
+	if cfg == nil {
+		return nil
+	}
+	clone := *cfg
+	clone.FFmpegDetectedEncoders = append([]string(nil), cfg.FFmpegDetectedEncoders...)
+	if cfg.ClipActionSettings != nil {
+		settings := *cfg.ClipActionSettings
+		clone.ClipActionSettings = &settings
+	}
+	return &clone
+}
+
+// Clone returns an independent Config value suitable for passing across a
+// package boundary. It copies the mutable encoder slice and clip-action
+// pointer in addition to the value fields.
+func Clone(cfg *Config) *Config {
+	return cloneConfig(cfg)
+}

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -1,0 +1,176 @@
+package config
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStoreUpdateSerializesReadModifyWrite(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(filepath.Join(dir, "config.json"), dir)
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFirst) }) }
+	defer release()
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := store.Update(func(cfg *Config) error {
+			cfg.LastChangelogVersion = "first"
+			close(firstEntered)
+			<-releaseFirst
+			return nil
+		})
+		firstErr <- err
+	}()
+	select {
+	case <-firstEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first update did not enter mutate")
+	}
+
+	secondEntered := make(chan struct{})
+	secondErr := make(chan error, 1)
+	go func() {
+		_, err := store.Update(func(cfg *Config) error {
+			close(secondEntered)
+			cfg.FiveEPlayerName = "second"
+			return nil
+		})
+		secondErr <- err
+	}()
+	select {
+	case <-secondEntered:
+		t.Fatal("second update entered mutate while first transaction was held")
+	case <-time.After(50 * time.Millisecond):
+	}
+	release()
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first update: %v", err)
+	}
+	if err := <-secondErr; err != nil {
+		t.Fatalf("second update: %v", err)
+	}
+
+	cfg, err := store.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if cfg.LastChangelogVersion != "first" || cfg.FiveEPlayerName != "second" {
+		t.Fatalf("serialized updates lost data: %+v", cfg)
+	}
+}
+
+func TestStoreSnapshotCopiesMutableFields(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(filepath.Join(dir, "config.json"), dir)
+	if _, err := store.Update(func(cfg *Config) error {
+		cfg.FFmpegDetectedEncoders = []string{"h264_nvenc", "libx264"}
+		cfg.ClipActionSettings = Ptr(ClipActionSettings{EnableVoiceIndices: true, EnableVoiceIndicesH: true})
+		return nil
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	first, err := store.Snapshot()
+	if err != nil {
+		t.Fatalf("first snapshot: %v", err)
+	}
+	first.FFmpegDetectedEncoders[0] = "mutated"
+	first.FFmpegDetectedEncoders = append(first.FFmpegDetectedEncoders, "extra")
+	first.ClipActionSettings.EnableVoiceIndices = false
+
+	second, err := store.Snapshot()
+	if err != nil {
+		t.Fatalf("second snapshot: %v", err)
+	}
+	if second.FFmpegDetectedEncoders[0] != "h264_nvenc" || len(second.FFmpegDetectedEncoders) != 2 {
+		t.Fatalf("encoder slice leaked through snapshot: %+v", second.FFmpegDetectedEncoders)
+	}
+	if second.ClipActionSettings == nil || !second.ClipActionSettings.EnableVoiceIndices {
+		t.Fatalf("clip action pointer leaked through snapshot: %+v", second.ClipActionSettings)
+	}
+}
+
+func TestStoreFailedTransactionsDoNotPublish(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(filepath.Join(dir, "config.json"), dir)
+	if _, err := store.Snapshot(); err != nil {
+		t.Fatalf("initialize config: %v", err)
+	}
+	mutateErr := errors.New("mutate failed")
+	if _, err := store.Update(func(cfg *Config) error {
+		cfg.FiveEPlayerName = "not committed"
+		return mutateErr
+	}); !errors.Is(err, mutateErr) {
+		t.Fatalf("mutate error = %v, want %v", err, mutateErr)
+	}
+	cfg, err := store.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot after mutate failure: %v", err)
+	}
+	if cfg.FiveEPlayerName != "" {
+		t.Fatalf("failed mutate was published: %q", cfg.FiveEPlayerName)
+	}
+
+	saveErr := errors.New("save failed")
+	store.saveFn = func(string, *Config) error { return saveErr }
+	if _, err := store.Update(func(cfg *Config) error {
+		cfg.FiveEPlayerName = "not saved"
+		return nil
+	}); !errors.Is(err, saveErr) {
+		t.Fatalf("save error = %v, want %v", err, saveErr)
+	}
+	store.saveFn = nil
+	cfg, err = store.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot after save failure: %v", err)
+	}
+	if cfg.FiveEPlayerName != "" {
+		t.Fatalf("failed save was published: %q", cfg.FiveEPlayerName)
+	}
+
+	firstWriteDir := t.TempDir()
+	firstWriteStore := NewStore(filepath.Join(firstWriteDir, "config.json"), firstWriteDir)
+	firstWriteStore.saveFn = func(string, *Config) error { return saveErr }
+	if _, err := firstWriteStore.Update(func(cfg *Config) error {
+		cfg.FiveEPlayerName = "never written"
+		return nil
+	}); !errors.Is(err, saveErr) {
+		t.Fatalf("first-write save error = %v, want %v", err, saveErr)
+	}
+	if _, err := firstWriteStore.Snapshot(); !errors.Is(err, saveErr) {
+		t.Fatalf("first-write snapshot error = %v, want %v", err, saveErr)
+	}
+}
+
+func TestStoreWorkspaceIdentityAndClose(t *testing.T) {
+	firstDir := t.TempDir()
+	secondDir := t.TempDir()
+	first := NewStore(filepath.Join(firstDir, "config.json"), firstDir)
+	second := NewStore(filepath.Join(secondDir, "config.json"), secondDir)
+	if _, err := first.Update(func(cfg *Config) error {
+		cfg.FiveEPlayerName = "first"
+		return nil
+	}); err != nil {
+		t.Fatalf("first update: %v", err)
+	}
+	if _, err := second.Update(func(cfg *Config) error {
+		cfg.FiveEPlayerName = "second"
+		return nil
+	}); err != nil {
+		t.Fatalf("second update: %v", err)
+	}
+	first.Close()
+	if _, err := first.Update(func(cfg *Config) error { return nil }); !errors.Is(err, ErrStoreClosed) {
+		t.Fatalf("closed update error = %v, want ErrStoreClosed", err)
+	}
+	if _, err := second.Snapshot(); err != nil {
+		t.Fatalf("independent store closed unexpectedly: %v", err)
+	}
+	if first.Path() == second.Path() || first.DataRoot() == second.DataRoot() {
+		t.Fatal("workspace stores unexpectedly share identity")
+	}
+}

--- a/internal/envsetup/config_store_test.go
+++ b/internal/envsetup/config_store_test.go
@@ -1,0 +1,94 @@
+package envsetup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cs2-highlight-tool-v2/internal/config"
+)
+
+func TestServicePersistConfigPublishesCommittedSnapshot(t *testing.T) {
+	exeDir := t.TempDir()
+	dataDir := t.TempDir()
+	svc := NewWithDataDir(exeDir, dataDir, "test")
+	svc.Startup(nil)
+	if _, err := svc.persistConfig(func(cfg *config.Config) error {
+		cfg.FFmpegDetectedPreset = "n1_h264"
+		cfg.FFmpegDetectedEncoders = []string{"libx264"}
+		return nil
+	}); err != nil {
+		t.Fatalf("persist config: %v", err)
+	}
+	stored, err := svc.ConfigStore().Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if stored.FFmpegDetectedPreset != "n1_h264" || len(stored.FFmpegDetectedEncoders) != 1 {
+		t.Fatalf("persisted detection cache missing: %+v", stored)
+	}
+	current := svc.currentConfig()
+	if current.FFmpegDetectedPreset != stored.FFmpegDetectedPreset {
+		t.Fatalf("service snapshot diverged from Store: %+v vs %+v", current, stored)
+	}
+}
+
+func TestServiceConfigPublicationRejectsOlderRevision(t *testing.T) {
+	exeDir := t.TempDir()
+	dataDir := t.TempDir()
+	svc := NewWithDataDir(exeDir, dataDir, "test")
+	store := svc.ConfigStore()
+	if _, _, err := store.SnapshotWithRevision(); err != nil {
+		t.Fatalf("initial snapshot: %v", err)
+	}
+	old, oldRevision, err := store.SnapshotWithRevision()
+	if err != nil {
+		t.Fatalf("old snapshot: %v", err)
+	}
+	newer, newerRevision, err := store.UpdateWithRevision(func(cfg *config.Config) error {
+		cfg.RecordQuality = "ultra"
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newer update: %v", err)
+	}
+	svc.ApplyConfigSnapshot(newer, newerRevision)
+	svc.ApplyConfigSnapshot(old, oldRevision)
+	if got := svc.currentConfig().RecordQuality; got != "ultra" {
+		t.Fatalf("older revision replaced newer snapshot: %q", got)
+	}
+}
+
+func TestServiceStopClosesConfigStore(t *testing.T) {
+	svc := NewWithDataDir(t.TempDir(), t.TempDir(), "test")
+	store := svc.ConfigStore()
+	if err := svc.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if _, err := store.Update(func(*config.Config) error { return nil }); !errors.Is(err, config.ErrStoreClosed) {
+		t.Fatalf("store update after Stop = %v, want ErrStoreClosed", err)
+	}
+}
+
+func TestServiceStopTimeoutStillClosesConfigStore(t *testing.T) {
+	svc := NewWithDataDir(t.TempDir(), t.TempDir(), "test")
+	store := svc.ConfigStore()
+	_, release, ok := svc.beginTaskIfOpen()
+	if !ok {
+		t.Fatal("service task was not admitted")
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	err := svc.Stop(stopCtx)
+	cancel()
+	if err == nil {
+		t.Fatal("Stop unexpectedly succeeded while a task was held")
+	}
+	if _, updateErr := store.Update(func(*config.Config) error { return nil }); !errors.Is(updateErr, config.ErrStoreClosed) {
+		t.Fatalf("store update after timed-out Stop = %v, want ErrStoreClosed", updateErr)
+	}
+	release()
+	if err := svc.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop retry: %v", err)
+	}
+}

--- a/internal/envsetup/service.go
+++ b/internal/envsetup/service.go
@@ -18,12 +18,14 @@ type Service struct {
 	exeDir     string
 	dataDir    string
 	configPath string
+	store      *config.Store
 	config     *config.Config
 	version    string
 
-	state    StartupState
-	mu       sync.Mutex
-	configMu sync.Mutex
+	state          StartupState
+	mu             sync.Mutex
+	configRevision uint64
+	storeMu        sync.Mutex
 
 	runTasksFn      func(source DownloadSource)
 	logger          logging.Logger
@@ -69,12 +71,28 @@ func NewWithDataDir(exeDir string, dataDir string, version string) *Service {
 	if dataDir == "" {
 		dataDir = exeDir
 	}
+	store := config.NewStore(filepath.Join(dataDir, "config.json"), dataDir)
+	return NewWithDataDirAndStore(exeDir, dataDir, version, store)
+}
+
+// NewWithDataDirAndStore constructs a service with the workspace's shared
+// configuration store. NewWithDataDir remains the compatibility constructor
+// for focused tests and development callers; production workspace creation
+// constructs the Store once and injects it here.
+func NewWithDataDirAndStore(exeDir string, dataDir string, version string, store *config.Store) *Service {
+	if dataDir == "" {
+		dataDir = exeDir
+	}
+	if store == nil {
+		store = config.NewStore(filepath.Join(dataDir, "config.json"), dataDir)
+	}
 	cfg := config.Default(dataDir)
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 	s := &Service{
 		exeDir:          exeDir,
 		dataDir:         dataDir,
-		configPath:      filepath.Join(dataDir, "config.json"),
+		configPath:      store.Path(),
+		store:           store,
 		config:          cfg,
 		version:         version,
 		state:           newStartupState(cfg, version),
@@ -87,6 +105,19 @@ func NewWithDataDir(exeDir string, dataDir string, version string) *Service {
 	})
 	s.runTasksFn = s.runTasksDefault
 	return s
+}
+
+// ConfigStore exposes the immutable store identity to the owning App
+// workspace. It is not a Wails method; callers must use Store's Snapshot or
+// Update methods rather than retaining mutable Config pointers.
+func (s *Service) ConfigStore() *config.Store {
+	if s == nil {
+		return nil
+	}
+	s.storeMu.Lock()
+	store := s.store
+	s.storeMu.Unlock()
+	return store
 }
 
 // BindLifecycleContext attaches a workspace-owned parent context to this
@@ -208,6 +239,9 @@ func (s *Service) CloseIfIdle() bool {
 	if cancel != nil {
 		cancel()
 	}
+	if store := s.ConfigStore(); store != nil {
+		store.Close()
+	}
 	return true
 }
 
@@ -234,6 +268,12 @@ func (s *Service) Stop(contexts ...context.Context) error {
 	s.tasksClosed = true
 	cancelLifecycle := s.lifecycleCancel
 	s.taskMu.Unlock()
+	// Close the config boundary as soon as admission closes. Tasks already in
+	// flight may finish their cancellation path, but a timed-out Stop must not
+	// leave a closed workspace able to publish another config write.
+	if store := s.ConfigStore(); store != nil {
+		store.Close()
+	}
 	if cancelLifecycle != nil {
 		cancelLifecycle()
 	}
@@ -264,7 +304,15 @@ func (s *Service) Startup(ctx context.Context) {
 	if s.exeDir == "" {
 		return
 	}
-	cfg, err := config.LoadOrCreate(s.configPath, s.dataDir)
+	store := s.ConfigStore()
+	var cfg *config.Config
+	var revision uint64
+	var err error
+	if store != nil {
+		cfg, revision, err = store.SnapshotWithRevision()
+	} else {
+		err = fmt.Errorf("配置存储未初始化")
+	}
 	if err != nil {
 		cfg = config.Default(s.dataDir)
 		s.emitLog("error", fmt.Sprintf("加载配置失败: %v", err))
@@ -273,7 +321,16 @@ func (s *Service) Startup(ctx context.Context) {
 		return
 	}
 	s.mu.Lock()
+	if revision != 0 && revision < s.configRevision && s.config != nil {
+		// An App transaction may have committed and published a newer snapshot
+		// while Startup was reading the file. Keep the newer in-memory fact
+		// source instead of restoring the older read result.
+		cfg = config.Clone(s.config)
+		revision = s.configRevision
+	}
+	cfg = config.Clone(cfg)
 	s.config = cfg
+	s.configRevision = revision
 	s.state = newStartupState(cfg, s.version)
 	s.logs = nil
 	s.releaseSnapshot = nil

--- a/internal/envsetup/service_startup.go
+++ b/internal/envsetup/service_startup.go
@@ -79,7 +79,15 @@ func (s *Service) RunStartupChecks() StartupState {
 	loadConfigStart := s.logStepStart("startup", "load_config", "read", "", 0, map[string]string{
 		"config_path": s.configPath,
 	})
-	cfg, err := config.LoadOrCreate(s.configPath, s.dataDir)
+	store := s.ConfigStore()
+	var cfg *config.Config
+	var revision uint64
+	var err error
+	if store != nil {
+		cfg, revision, err = store.SnapshotWithRevision()
+	} else {
+		err = fmt.Errorf("配置存储未初始化")
+	}
 	if err != nil {
 		s.logStepFail("startup", "load_config", "read", "", 0, loadConfigStart, err, map[string]string{
 			"config_path": s.configPath,
@@ -90,10 +98,9 @@ func (s *Service) RunStartupChecks() StartupState {
 	s.logStepDone("startup", "load_config", "read", "", 0, loadConfigStart, map[string]string{
 		"config_path": s.configPath,
 	})
-	s.mu.Lock()
-	s.config = cfg
-	s.mu.Unlock()
-	s.updateConfig(cfg)
+	if s.applyConfigSnapshot(cfg, revision) {
+		s.emitState()
+	}
 	if s.isStopped() {
 		return s.GetStartupState()
 	}

--- a/internal/envsetup/service_state.go
+++ b/internal/envsetup/service_state.go
@@ -198,25 +198,48 @@ func (s *Service) updateStep(componentID string, mutate func(*ComponentStatus)) 
 }
 
 func (s *Service) updateConfig(cfg *config.Config) {
-	if cfg == nil || s.isStopped() {
-		return
+	if s.applyConfigSnapshot(cfg, 0) {
+		s.emitState()
 	}
+}
+
+// ApplyConfigSnapshot updates the service's derived startup state after an
+// App transaction commits through the shared Store. The method is internal to
+// the App/envsetup boundary (not a Wails API) and intentionally emits no event;
+// settings writes historically did not emit startup_state_changed.
+func (s *Service) ApplyConfigSnapshot(cfg *config.Config, revision uint64) {
+	s.applyConfigSnapshot(cfg, revision)
+}
+
+func (s *Service) applyConfigSnapshot(cfg *config.Config, revision uint64) bool {
+	if cfg == nil || s.isStopped() {
+		return false
+	}
+	snapshot := config.Clone(cfg)
 	s.mu.Lock()
-	s.state.Config = *cfg
+	if revision != 0 && revision < s.configRevision {
+		s.mu.Unlock()
+		return false
+	}
+	if revision > s.configRevision {
+		s.configRevision = revision
+	}
+	s.config = snapshot
+	s.state.Config = *config.Clone(snapshot)
 	for i := range s.state.Steps {
 		switch s.state.Steps[i].ID {
 		case componentHLAE:
-			s.state.Steps[i].Path = cfg.HLAEExe
+			s.state.Steps[i].Path = snapshot.HLAEExe
 		case componentPlugin:
-			s.state.Steps[i].Path = cfg.PluginDLL
+			s.state.Steps[i].Path = snapshot.PluginDLL
 		case componentFFmpeg:
-			s.state.Steps[i].Path = filepath.Join(cfg.FFmpegDir, "ffmpeg.exe")
+			s.state.Steps[i].Path = filepath.Join(snapshot.FFmpegDir, "ffmpeg.exe")
 		case componentCS2:
-			s.state.Steps[i].Path = cfg.CS2Exe
+			s.state.Steps[i].Path = snapshot.CS2Exe
 		}
 	}
 	s.mu.Unlock()
-	s.emitState()
+	return true
 }
 
 func (s *Service) currentConfig() config.Config {
@@ -225,38 +248,30 @@ func (s *Service) currentConfig() config.Config {
 	if s.config == nil {
 		return *config.Default(s.dataDir)
 	}
-	return *s.config
+	return *config.Clone(s.config)
 }
 
 func (s *Service) persistConfig(mutate func(*config.Config) error) (*config.Config, error) {
 	if s.isStopped() {
 		return nil, errServiceStopped
 	}
-	s.configMu.Lock()
-	defer s.configMu.Unlock()
-	if s.isStopped() {
-		return nil, errServiceStopped
+	store := s.ConfigStore()
+	if store == nil {
+		return nil, fmt.Errorf("配置存储未初始化")
 	}
-
-	cfg, err := config.LoadOrCreate(s.configPath, s.dataDir)
+	cfg, revision, err := store.UpdateWithRevision(mutate)
 	if err != nil {
-		return nil, err
-	}
-	if mutate != nil {
-		if err := mutate(cfg); err != nil {
-			return nil, err
+		if errors.Is(err, config.ErrStoreClosed) {
+			return nil, errServiceStopped
 		}
-	}
-	if err := config.Save(s.configPath, cfg); err != nil {
 		return nil, err
 	}
 	if s.isStopped() {
 		return nil, errServiceStopped
 	}
-	s.mu.Lock()
-	s.config = cfg
-	s.mu.Unlock()
-	s.updateConfig(cfg)
+	if s.applyConfigSnapshot(cfg, revision) {
+		s.emitState()
+	}
 	return cfg, nil
 }
 

--- a/internal/envsetup/state.go
+++ b/internal/envsetup/state.go
@@ -153,5 +153,6 @@ func newStartupState(cfg *config.Config, currentVersion string) StartupState {
 func (s StartupState) clone() StartupState {
 	s.Steps = append([]ComponentStatus(nil), s.Steps...)
 	s.Ads = append([]StartupAd(nil), s.Ads...)
+	s.Config = *config.Clone(&s.Config)
 	return s
 }


### PR DESCRIPTION
## Summary
- introduce a workspace-bound config Store with serialized snapshots and updates
- share one Store between App and envsetup Service per workspace
- harden close/revision behavior to prevent stale writes during workspace lifecycle changes
- add config Store, cross-layer concurrency, and shutdown tests

## Validation
- go test ./...
- go test -race ./internal/config ./internal/app ./internal/envsetup
- go vet ./...
- git diff --check