### PR TITLE
fix: transactional installs, atomic demo caches, and import coordination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ CS2 Demo 导入、片段选择、自动录制与后期拼接的 Windows 桌面�
 - `PickDemoFiles` 返回受管控路径 `<dataDir>/demo/raw/...`，不直接返回原始选择路径。
 - `ListWanmeiRecentMatches(page)` 将小于 1 的页码归一为 1；状态为 `client_not_running|client_not_logged_in|ready`，战绩包含 `download_match_id/k4/k5/rating`。`ImportWanmeiMatch` 接受 `PVP@...`，产物为 `<dataDir>/demo/wanmei/<matchID>/<matchID>.dem`。
 - `GetFiveEPlayerName` 读取持久化 `fivee_player_name`；`ListFiveERecentMatches(playerName, page)` 接受 ID 或含 `domain=<id>` 的分享链接，先规范化并保存 domain ID，页码最小为 1，战绩包含 `match_id/download_match_id/rating`。`ImportFiveEMatch` 接受 ID/URL/zip 名，产物为 `<dataDir>/demo/5e/<matchID>/<matchID>.dem`。
+- 平台导入仅在解压文件经 `internal/download.CopyFile` 的同目录临时文件、Copy/Close 检查和 rename 提交完成后返回成功；失败只清理本次临时文件并保留旧目标。旧缓存命中前仅做 regular、长度和 `PBDEMS2`/`HL2DEMO` 文件戳的基本校验，不能据此证明尾部未截断；校验失败会重新获取，不默认引入版本化提交标记或强制全量重下。
 - `ParseDemoFile` 的 `players[]` 包含 `name/steam_id/steam_id_text/kills/deaths/assists`，不包含 `team`；`clip_players[]` 按玩家、回合、击杀组织。前端请求必须使用字符串 SteamID，不能将 JS number 的 `steam_id` 转回字符串使用。
 
 ### 设置与插件计划

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ CS2 Demo 导入、片段选择、自动录制与后期拼接的 Windows 桌面�
 - `ListWanmeiRecentMatches(page)` 将小于 1 的页码归一为 1；状态为 `client_not_running|client_not_logged_in|ready`，战绩包含 `download_match_id/k4/k5/rating`。`ImportWanmeiMatch` 接受 `PVP@...`，产物为 `<dataDir>/demo/wanmei/<matchID>/<matchID>.dem`。
 - `GetFiveEPlayerName` 读取持久化 `fivee_player_name`；`ListFiveERecentMatches(playerName, page)` 接受 ID 或含 `domain=<id>` 的分享链接，先规范化并保存 domain ID，页码最小为 1，战绩包含 `match_id/download_match_id/rating`。`ImportFiveEMatch` 接受 ID/URL/zip 名，产物为 `<dataDir>/demo/5e/<matchID>/<matchID>.dem`。
 - 平台导入仅在解压文件经 `internal/download.CopyFile` 的同目录临时文件、Copy/Close 检查和 rename 提交完成后返回成功；失败只清理本次临时文件并保留旧目标。旧缓存命中前仅做 regular、长度和 `PBDEMS2`/`HL2DEMO` 文件戳的基本校验，不能据此证明尾部未截断；校验失败会重新获取，不默认引入版本化提交标记或强制全量重下。
+- 同一工作目录内按 `(平台, 规范化 matchID)` 共享在途导入任务（`internal/app/import_coordinator.go`）：同键并发只执行一次真实下载/解压/提交并返回同一路径，不同键继续并行，5e 与 wanmei 的同文本 ID 不得合并。失败不缓存，重试会重新执行真实任务；等待者退出只退出自己的等待。共享任务运行在工作目录生命周期 context 下并持有文件使用权直到真实任务退出，工作目录关闭会取消下载与解压（`download.UnzipWithContext` 在遍历和复制过程中检查 ctx）且不提交缓存；`download_progress` 只由真实任务发出。
 - `ParseDemoFile` 的 `players[]` 包含 `name/steam_id/steam_id_text/kills/deaths/assists`，不包含 `team`；`clip_players[]` 按玩家、回合、击杀组织。前端请求必须使用字符串 SteamID，不能将 JS number 的 `steam_id` 转回字符串使用。
 
 ### 设置与插件计划

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ CS2 Demo 导入、片段选择、自动录制与后期拼接的 Windows 桌面�
 - 启动时实时 GeoIP 检测，统一更新源固定为 `github`，地区结果不持久化。先获取统一 Release 快照，再检查软件自身更新；确认 `self_update.available=true` 时必须先更新软件，不启动组件检查/安装。自更新检查失败保持非致命语义。
 - 组件下载策略：CN 或 GeoIP 失败/为空时，`mirror_url` 与 `url` 并行竞速，先成功完成的链路胜出并取消另一条；非 CN 仅 `github_url`。竞速全部失败才报错，不恢复多源自动回退或 gh-proxy 终极兜底。统一源失败可使用本地已安装组件并标记 warning，不伪造远端成功。
 - HLAE、插件本地版本均来自各自安装目录 `changelog.xml` 首个 `<version>`，不以配置持久化版本为真值。
+- HLAE/FFmpeg 目录安装使用 `internal/download.ReplaceDirWithContents` 的提交事务：先在目标同卷创建本次唯一 staging 并完成复制，再将旧目标移到本次唯一 backup，最后 rename 提交；备份 rename、提交或恢复失败不得主动删除旧版本，恢复失败须保留 staging/backup 并返回双重错误及路径。提交成功后的 backup 清理失败只作为告警并保留 backup，不得被当成安装失败触发破坏性重试；历史遗留 `.old` 或事务目录不属于本次所有权，不得无条件删除。组件必需文件由 envsetup 在提交前验证，`ReplaceDirWithContentsWithReport` 的清理告警由调用方记录。该事务不宣称覆盖进程在两次 rename 之间崩溃的自动恢复。
 - `StartupState.ads[]` 仅包含有效的 `main_steps_top_banner` Sponsored Card，展示字段为 `click_url/sponsor/title/rich_html/image_url/image_alt`；点击走外部浏览器，广告失败不得阻断启动。
 
 ### Demo 导入与解析

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -10,6 +10,7 @@
 - Demo 事实与整局 POV 解析在 `demo/`，片段归一化与生成编排在 `app/plugin_generate.go`，插件命令构建在 `clipsjson/`。
 - 会话、清理和文件占用分别从 `app/produce_session.go`、`app/produce_cleanup.go`、`app/work_activity.go` 查起；WebSocket 状态与协议在 `producews/`。
 - Windows 专用行为与其他平台实现通过现有平台文件分开维护；非 Windows 测试不能替代 Windows 运行验证。
+- `download.ReplaceDirWithContents` 只承担目录文件系统提交，不包含 HLAE/FFmpeg 组件判断。实现必须使用本次实例创建且可确认归属的唯一 staging/backup；准备或备份失败保持旧 target，提交失败先尝试恢复，恢复失败保留两条恢复路径并返回主/恢复双重错误。提交成功但旧 backup 清理失败通过 `ReplaceDirWithContentsWithReport` 暴露为告警，不得回报为安装失败；不触碰既有 `.old` 或未知事务残留。文件系统故障注入使用实例依赖，不增加包级可写 seam。
 
 ## 工作目录与启动状态机
 

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -8,10 +8,12 @@
 - 启动状态模型与通知入口：`envsetup/state.go`、`envsetup/events.go`；检查/动作/状态逻辑按 `service_*.go` 分工。
 - 配置默认值、归一化和兼容处理集中在 `config/config.go`；同一工作目录的读改写事务由 `config.Store` 统一串行化并由 App 注入 `envsetup.Service`；应用层设置映射在 `app/clip_settings.go`。
 - Demo 事实与整局 POV 解析在 `demo/`，片段归一化与生成编排在 `app/plugin_generate.go`，插件命令构建在 `clipsjson/`。
+- 平台导入协调（同键去重、等待者、结果固定与清理）在 `app/import_coordinator.go`，由工作目录身份持有并在切换/重置时替换；`fivee`、`wanmei` 只负责来源解析、下载解压与缓存提交，不互相依赖。
 - 会话、清理和文件占用分别从 `app/produce_session.go`、`app/produce_cleanup.go`、`app/work_activity.go` 查起；WebSocket 状态与协议在 `producews/`。
 - Windows 专用行为与其他平台实现通过现有平台文件分开维护；非 Windows 测试不能替代 Windows 运行验证。
 - `download.ReplaceDirWithContents` 只承担目录文件系统提交，不包含 HLAE/FFmpeg 组件判断。实现必须使用本次实例创建且可确认归属的唯一 staging/backup；准备或备份失败保持旧 target，提交失败先尝试恢复，恢复失败保留两条恢复路径并返回主/恢复双重错误。提交成功但旧 backup 清理失败通过 `ReplaceDirWithContentsWithReport` 暴露为告警，不得回报为安装失败；不触碰既有 `.old` 或未知事务残留。文件系统故障注入使用实例依赖，不增加包级可写 seam。
 - `download.CopyFile` 是兼容入口，但使用同目录临时文件完成 Copy、Close 检查和提交 rename；缓存导入通过 `IsLikelyDemoFile` 只做基本文件戳校验，不能把命中结果当作完整性证明。原子复制的故障注入通过实例 `atomicCopyOps`，不得引入包级可写 seam。
+- `download.UnzipWithContext` 在打开归档、每个条目和每次复制之间检查 ctx，长解压可被工作目录关闭打断；`download.Unzip` 是无取消的兼容入口，故障注入通过实例 `unzipOps`。平台导入解压 seam 因此接收 ctx，组件安装等旧调用者继续使用兼容入口。
 
 ## 工作目录与启动状态机
 
@@ -27,7 +29,7 @@
 - `Service.state`、`Service.logs`、已提交的 `Service.config` 快照由 `Service.mu` 保护；配置文件的最新读取、归一化、mutate 和保存只走工作目录共享的 `config.Store`，不再为 App/Service 各自维护文件锁。工作目录准入后再进入 Store，保存成功后才更新 Service 快照，事件必须在 Store 解锁后发射；应用 service 的访问遵循 `serviceMu`。
 - `app/workspace_session.go` 的私有 `workspaceSession` 持有不可变 root/generation/service 与生命周期 context；任务须在启动前登记。切换/退出先关闭准入，再取消并等待，不得在 service/state 锁内等待、做 I/O 或发射事件。`envsetup.Service` 的 `BindLifecycleContext`、`CloseIfIdle`、`Stop` 仅由 App 的 session 生命周期调用，旧实例关闭后不得重新接收任务。
 - 避免锁内执行阻塞 I/O、网络或 runtime 事件发射，不引入锁顺序反转。启动状态更新后通过 `emitState()` 通知前端；制作事件复用现有队列。
-- `GetWorkActivity` 的前端禁用策略不代替后端互斥；文件读写/导出/清理复用现有文件使用权机制。
+- `GetWorkActivity` 的前端禁用策略不代替后端互斥；文件读写/导出/清理复用现有文件使用权机制。多个调用者共享的长任务（如平台导入）必须用 `beginManagedWorkspaceTaskUse` 的工作目录 context 运行并持有所属准入直到真实任务退出；等待者取消不得取消共享任务，进度与提交等副作用只由真实任务执行。
 - 制作生命周期遵循根文件“制作、剪辑与清理”：活跃会话禁止重复生成，失败收尾保留重试所需状态；未确认进程退出、环境恢复前不得提前释放备份和占用。
 - HLAE 启动成功但 CS2 PID 未知时，保留启动器句柄并核对进程枚举；不能因 PID 为空直接恢复环境，也不能关闭归属不明的游戏进程。
 - 涉及会话退出、取消和 FFmpeg 合并时，检查等待、探测及子进程是否遵循现有取消/超时机制，避免收尾后旧任务继续写文件。

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -12,7 +12,7 @@
 - 会话、清理和文件占用分别从 `app/produce_session.go`、`app/produce_cleanup.go`、`app/work_activity.go` 查起；WebSocket 状态与协议在 `producews/`。
 - Windows 专用行为与其他平台实现通过现有平台文件分开维护；非 Windows 测试不能替代 Windows 运行验证。
 - `download.ReplaceDirWithContents` 只承担目录文件系统提交，不包含 HLAE/FFmpeg 组件判断。实现必须使用本次实例创建且可确认归属的唯一 staging/backup；准备或备份失败保持旧 target，提交失败先尝试恢复，恢复失败保留两条恢复路径并返回主/恢复双重错误。提交成功但旧 backup 清理失败通过 `ReplaceDirWithContentsWithReport` 暴露为告警，不得回报为安装失败；不触碰既有 `.old` 或未知事务残留。文件系统故障注入使用实例依赖，不增加包级可写 seam。
-- `download.CopyFile` 是兼容入口，但使用同目录临时文件完成 Copy、Close 检查和提交 rename；缓存导入通过 `IsLikelyDemoFile` 只做基本文件戳校验，不能把命中结果当作完整性证明。原子复制的故障注入通过实例 `atomicCopyOps`，不得引入包级可写 seam。
+- `download.CopyFile` 是兼容入口，但使用同目录临时文件完成 Copy、Close 检查和提交 rename；缓存导入通过 `IsLikelyDemoFile` 只做基本文件戳校验，不能把命中结果当作完整性证明。目标已存在但不是普通文件（尤其是目录）时必须在移动目标前拒绝，不得把目录移入备份路径后用文件覆盖。原子复制的故障注入通过实例 `atomicCopyOps`，不得引入包级可写 seam。
 - `download.UnzipWithContext` 在打开归档、每个条目和每次复制之间检查 ctx，长解压可被工作目录关闭打断；`download.Unzip` 是无取消的兼容入口，故障注入通过实例 `unzipOps`。平台导入解压 seam 因此接收 ctx，组件安装等旧调用者继续使用兼容入口。
 
 ## 工作目录与启动状态机

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -11,6 +11,7 @@
 - 会话、清理和文件占用分别从 `app/produce_session.go`、`app/produce_cleanup.go`、`app/work_activity.go` 查起；WebSocket 状态与协议在 `producews/`。
 - Windows 专用行为与其他平台实现通过现有平台文件分开维护；非 Windows 测试不能替代 Windows 运行验证。
 - `download.ReplaceDirWithContents` 只承担目录文件系统提交，不包含 HLAE/FFmpeg 组件判断。实现必须使用本次实例创建且可确认归属的唯一 staging/backup；准备或备份失败保持旧 target，提交失败先尝试恢复，恢复失败保留两条恢复路径并返回主/恢复双重错误。提交成功但旧 backup 清理失败通过 `ReplaceDirWithContentsWithReport` 暴露为告警，不得回报为安装失败；不触碰既有 `.old` 或未知事务残留。文件系统故障注入使用实例依赖，不增加包级可写 seam。
+- `download.CopyFile` 是兼容入口，但使用同目录临时文件完成 Copy、Close 检查和提交 rename；缓存导入通过 `IsLikelyDemoFile` 只做基本文件戳校验，不能把命中结果当作完整性证明。原子复制的故障注入通过实例 `atomicCopyOps`，不得引入包级可写 seam。
 
 ## 工作目录与启动状态机
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -32,6 +32,11 @@ type App struct {
 	workspace           *workspaceSession
 	workspaceGeneration uint64
 	configStore         *config.Store
+	// platformImports coordinates same-key platform demo imports for the
+	// installed workspace identity. It is replaced together with that identity
+	// (guarded by serviceMu) so tasks from a removed workspace can never be
+	// joined by a new one.
+	platformImports *platformImportCoordinator
 
 	produceStateMu sync.Mutex
 	produceState   produceSessionState

--- a/internal/app/app_fivee.go
+++ b/internal/app/app_fivee.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -54,7 +55,10 @@ func (a *App) saveFiveEPlayerName(playerName string) error {
 }
 
 func (a *App) ImportFiveEMatch(matchID string) ([]string, error) {
-	releaseFiles, dataDir, fileErr := a.beginManagedWorkspaceUse()
+	// The admission comes before match-ID validation so a rejected directory
+	// operation can never be bypassed by an import; the same reservation is
+	// held until the shared import task really exits.
+	workCtx, releaseFiles, dataDir, fileErr := a.beginManagedWorkspaceTaskUse()
 	if fileErr != nil {
 		return nil, fileErr
 	}
@@ -67,13 +71,24 @@ func (a *App) ImportFiveEMatch(matchID string) ([]string, error) {
 	cacheRoot := filepath.Join(dataDir, "demo", "5e", downloadMatchID)
 	progressID := fivee.ProgressComponentID(downloadMatchID)
 
-	stablePath, err := fivee.ImportDemo(downloadMatchID, cacheRoot, func(active bool, percent float64, indeterminate bool) {
-		a.emitFiveEDownloadProgress(progressID, active, percent, indeterminate)
-	})
+	stablePath, ranImport, err := a.importCoordinator().do(
+		workCtx,
+		workCtx,
+		platformImportKey{platform: platformImportFiveE, matchID: downloadMatchID},
+		func(runCtx context.Context) (string, error) {
+			return fivee.ImportDemoContext(runCtx, downloadMatchID, cacheRoot, func(active bool, percent float64, indeterminate bool) {
+				a.emitFiveEDownloadProgress(progressID, active, percent, indeterminate)
+			})
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
-	a.cleanupLegacyRawDemoCopyAt(stablePath, dataDir)
+	// Only the caller that performed the real import owns one-time
+	// post-processing; waiters reuse the prepared result without repeating it.
+	if ranImport {
+		a.cleanupLegacyRawDemoCopyAt(stablePath, dataDir)
+	}
 	return []string{stablePath}, nil
 }
 

--- a/internal/app/app_fivee_test.go
+++ b/internal/app/app_fivee_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -133,7 +134,7 @@ func TestImportFiveEMatch_CleansUpLegacyRawDemo(t *testing.T) {
 	fivee.DownloadFileFn = func(url string, targetPath string, emitProgress download.ProgressFunc) error {
 		return os.WriteFile(targetPath, []byte("zip"), 0644)
 	}
-	fivee.UnzipFn = func(archivePath string, destDir string) error {
+	fivee.UnzipFn = func(ctx context.Context, archivePath string, destDir string) error {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return err
 		}

--- a/internal/app/app_wanmei.go
+++ b/internal/app/app_wanmei.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 
@@ -15,7 +16,9 @@ func (a *App) ListWanmeiRecentMatches(page int) (*wanmei.WanmeiMatchListResult, 
 }
 
 func (a *App) ImportWanmeiMatch(matchID string) ([]string, error) {
-	releaseFiles, dataDir, fileErr := a.beginManagedWorkspaceUse()
+	// See ImportFiveEMatch: the workspace reservation precedes normalization so
+	// a directory clear cannot be bypassed, and it covers the whole shared task.
+	workCtx, releaseFiles, dataDir, fileErr := a.beginManagedWorkspaceTaskUse()
 	if fileErr != nil {
 		return nil, fileErr
 	}
@@ -28,13 +31,22 @@ func (a *App) ImportWanmeiMatch(matchID string) ([]string, error) {
 	cacheRoot := filepath.Join(dataDir, "demo", "wanmei", downloadMatchID)
 	progressID := wanmei.ProgressComponentID(downloadMatchID)
 
-	stablePath, err := wanmei.ImportDemo(downloadMatchID, cacheRoot, func(active bool, percent float64, indeterminate bool) {
-		a.emitWanmeiDownloadProgress(progressID, active, percent, indeterminate)
-	})
+	stablePath, ranImport, err := a.importCoordinator().do(
+		workCtx,
+		workCtx,
+		platformImportKey{platform: platformImportWanmei, matchID: downloadMatchID},
+		func(runCtx context.Context) (string, error) {
+			return wanmei.ImportDemoContext(runCtx, downloadMatchID, cacheRoot, func(active bool, percent float64, indeterminate bool) {
+				a.emitWanmeiDownloadProgress(progressID, active, percent, indeterminate)
+			})
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
-	a.cleanupLegacyRawDemoCopyAt(stablePath, dataDir)
+	if ranImport {
+		a.cleanupLegacyRawDemoCopyAt(stablePath, dataDir)
+	}
 	return []string{stablePath}, nil
 }
 

--- a/internal/app/app_wanmei_test.go
+++ b/internal/app/app_wanmei_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -49,7 +50,7 @@ func TestImportWanmeiMatch_CleansUpLegacyRawDemo(t *testing.T) {
 	wanmei.DownloadFileFn = func(url string, targetPath string, emitProgress download.ProgressFunc) error {
 		return os.WriteFile(targetPath, []byte("zip"), 0644)
 	}
-	wanmei.UnzipFn = func(archivePath string, destDir string) error {
+	wanmei.UnzipFn = func(ctx context.Context, archivePath string, destDir string) error {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return err
 		}

--- a/internal/app/app_workspace.go
+++ b/internal/app/app_workspace.go
@@ -215,6 +215,7 @@ func (a *App) ResetWorkspace() error {
 	a.configStore = nil
 	a.workspace = nil
 	a.workspaceGeneration++
+	a.platformImports = nil
 	a.workspaceResetPendingPath = ""
 	a.workspaceResetRegistryPending = false
 	a.workspaceResetCompleted = true
@@ -237,6 +238,7 @@ func (a *App) detachWorkspaceForReset(dataDir string) {
 	a.configStore = nil
 	a.workspace = nil
 	a.workspaceGeneration++
+	a.platformImports = nil
 	a.workspaceResetPendingPath = dataDir
 	a.workspaceResetRegistryPending = runtime.GOOS == "windows"
 	a.serviceMu.Unlock()

--- a/internal/app/import_coordinator.go
+++ b/internal/app/import_coordinator.go
@@ -1,0 +1,166 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// platformImportPlatform identifies the platform client that owns a real demo
+// download. It participates in the coordination key so a 5E match ID can never
+// merge with a Wanmei ID that happens to have the same text.
+type platformImportPlatform string
+
+const (
+	platformImportFiveE  platformImportPlatform = "5e"
+	platformImportWanmei platformImportPlatform = "wanmei"
+)
+
+// platformImportKey is the normalized identity of one platform import. Callers
+// pass canonicalized match IDs (fivee.ExtractMatchID /
+// wanmei.ExtractNumericMatchID output), never a raw user URL, so equivalent
+// inputs share one task while different matches keep running in parallel.
+type platformImportKey struct {
+	platform platformImportPlatform
+	matchID  string
+}
+
+type platformImportResult struct {
+	path string
+	err  error
+}
+
+// platformImportTask is one in-flight real import. The owning caller writes
+// result before closing done; every waiter reads it only after <-done, so the
+// channel close publishes one frozen result to all of them.
+type platformImportTask struct {
+	done    chan struct{}
+	result  platformImportResult
+	waiters int
+}
+
+// platformImportCoordinator deduplicates concurrent imports of the same
+// (platform, normalized match ID) inside one workspace. Same-key callers share
+// a single download/extract/commit; different keys stay independent.
+//
+// The coordinator never holds its mutex across network or file work.
+// Registering a task, publishing the frozen result and removing the in-flight
+// entry are the only critical sections.
+type platformImportCoordinator struct {
+	mu    sync.Mutex
+	tasks map[platformImportKey]*platformImportTask
+}
+
+func newPlatformImportCoordinator() *platformImportCoordinator {
+	return &platformImportCoordinator{tasks: make(map[platformImportKey]*platformImportTask)}
+}
+
+// do runs fn for key and returns its result to every caller that arrives while
+// the task is in flight. The first caller performs the real work under runCtx;
+// later callers only wait. waitCtx bounds one waiter's own wait and never the
+// shared task: canceling it removes that waiter alone.
+//
+// Errors are not cached. The in-flight entry is removed before waiters wake,
+// so a caller that retries after a failure starts a new real import instead of
+// observing the finished one.
+//
+// The second return value reports whether this caller performed the real
+// import, which lets the caller run one-time post-processing exactly once.
+func (c *platformImportCoordinator) do(
+	runCtx context.Context,
+	waitCtx context.Context,
+	key platformImportKey,
+	fn func(context.Context) (string, error),
+) (path string, ranImport bool, err error) {
+	if runCtx == nil {
+		runCtx = context.Background()
+	}
+	if waitCtx == nil {
+		waitCtx = context.Background()
+	}
+	if c == nil {
+		path, err = fn(runCtx)
+		return path, true, err
+	}
+
+	c.mu.Lock()
+	if c.tasks == nil {
+		c.tasks = make(map[platformImportKey]*platformImportTask)
+	}
+	if task, ok := c.tasks[key]; ok {
+		task.waiters++
+		c.mu.Unlock()
+
+		path, err = task.wait(waitCtx)
+
+		c.mu.Lock()
+		if task.waiters > 0 {
+			task.waiters--
+		}
+		c.mu.Unlock()
+		return path, false, err
+	}
+	task := &platformImportTask{done: make(chan struct{})}
+	c.tasks[key] = task
+	c.mu.Unlock()
+
+	// Publish the result and wake waiters even if fn panics: leaking an
+	// in-flight entry would block every later caller for this key forever.
+	func() {
+		defer func() {
+			recovered := recover()
+			if recovered != nil {
+				err = fmt.Errorf("平台导入任务异常终止: %v", recovered)
+			}
+			c.mu.Lock()
+			task.result = platformImportResult{path: path, err: err}
+			delete(c.tasks, key)
+			c.mu.Unlock()
+			close(task.done)
+			if recovered != nil {
+				panic(recovered)
+			}
+		}()
+		path, err = fn(runCtx)
+	}()
+
+	return path, true, err
+}
+
+// waiterCount reports how many callers currently wait for the in-flight task
+// of key. Proving that a second caller joined the shared task (instead of
+// starting another download) is the main use; an owner-only import reports 0.
+func (c *platformImportCoordinator) waiterCount(key platformImportKey) int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	task := c.tasks[key]
+	if task == nil {
+		return 0
+	}
+	return task.waiters
+}
+
+func (t *platformImportTask) wait(ctx context.Context) (string, error) {
+	select {
+	case <-t.done:
+		return t.result.path, t.result.err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// importCoordinator returns the import coordinator owned by the installed
+// workspace identity. Production construction installs it with the identity;
+// manually constructed App fixtures that never installed one get a lazily
+// created coordinator so focused tests exercise the same coordination.
+func (a *App) importCoordinator() *platformImportCoordinator {
+	a.serviceMu.Lock()
+	defer a.serviceMu.Unlock()
+	if a.platformImports == nil {
+		a.platformImports = newPlatformImportCoordinator()
+	}
+	return a.platformImports
+}

--- a/internal/app/import_coordinator_test.go
+++ b/internal/app/import_coordinator_test.go
@@ -1,0 +1,346 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testPlatformImportKey(matchID string) platformImportKey {
+	return platformImportKey{platform: platformImportFiveE, matchID: matchID}
+}
+
+// waitForImportWaiters blocks until the in-flight task of key has at least
+// want waiters. Callers use it only after the owning import is already inside
+// the real task, so a later caller can only have joined the shared task; the
+// deadline turns a broken coordinator into a test failure instead of a hang.
+func waitForImportWaiters(t *testing.T, c *platformImportCoordinator, key platformImportKey, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if got := c.waiterCount(key); got >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d import waiter(s), got %d", want, c.waiterCount(key))
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestImportCoordinatorSharesSameKeyTask(t *testing.T) {
+	c := newPlatformImportCoordinator()
+	key := testPlatformImportKey("g161-20260427162329954189731")
+
+	var runs int32
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	fn := func(context.Context) (string, error) {
+		atomic.AddInt32(&runs, 1)
+		close(entered)
+		<-release
+		return "shared.dem", nil
+	}
+
+	type outcome struct {
+		path      string
+		ranImport bool
+		err       error
+	}
+	const callers = 4
+	results := make(chan outcome, callers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			path, ranImport, err := c.do(context.Background(), context.Background(), key, fn)
+			results <- outcome{path: path, ranImport: ranImport, err: err}
+		}()
+	}
+	close(start)
+	<-entered
+	// Every other caller must join the in-flight task before the real import
+	// can finish, so exactly one download is proven rather than assumed.
+	waitForImportWaiters(t, c, key, callers-1)
+	close(release)
+	wg.Wait()
+	close(results)
+
+	if got := atomic.LoadInt32(&runs); got != 1 {
+		t.Fatalf("real import runs = %d, want 1", got)
+	}
+	leaders := 0
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("shared import returned error: %v", result.err)
+		}
+		if result.path != "shared.dem" {
+			t.Fatalf("shared import path = %q, want %q", result.path, "shared.dem")
+		}
+		if result.ranImport {
+			leaders++
+		}
+	}
+	if leaders != 1 {
+		t.Fatalf("callers that ran the real import = %d, want 1", leaders)
+	}
+	if got := c.waiterCount(key); got != 0 {
+		t.Fatalf("waiters after completion = %d, want 0", got)
+	}
+}
+
+func TestImportCoordinatorRunsIndependentKeysInParallel(t *testing.T) {
+	cases := []struct {
+		name string
+		keys []platformImportKey
+	}{
+		{
+			name: "different match IDs",
+			keys: []platformImportKey{
+				{platform: platformImportFiveE, matchID: "g161-20260427162329954189731"},
+				{platform: platformImportFiveE, matchID: "g161-20260427162329954189732"},
+			},
+		},
+		{
+			name: "same ID on different platforms",
+			keys: []platformImportKey{
+				{platform: platformImportFiveE, matchID: "123"},
+				{platform: platformImportWanmei, matchID: "123"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newPlatformImportCoordinator()
+			entered := make(chan platformImportKey, len(tc.keys))
+			release := make(chan struct{})
+
+			type outcome struct {
+				key  platformImportKey
+				path string
+				err  error
+			}
+			results := make(chan outcome, len(tc.keys))
+			for _, key := range tc.keys {
+				key := key
+				fn := func(context.Context) (string, error) {
+					entered <- key
+					<-release
+					return key.matchID + ".dem", nil
+				}
+				go func() {
+					path, _, err := c.do(context.Background(), context.Background(), key, fn)
+					results <- outcome{key: key, path: path, err: err}
+				}()
+			}
+
+			// Both keys must reach the real task before either can finish.
+			seen := make(map[platformImportKey]bool, len(tc.keys))
+			for i := 0; i < len(tc.keys); i++ {
+				select {
+				case key := <-entered:
+					seen[key] = true
+				case <-time.After(2 * time.Second):
+					t.Fatalf("independent keys did not run in parallel, saw %v", seen)
+				}
+			}
+			close(release)
+
+			for i := 0; i < len(tc.keys); i++ {
+				select {
+				case result := <-results:
+					if result.err != nil {
+						t.Fatalf("independent import %v failed: %v", result.key, result.err)
+					}
+					if result.path != result.key.matchID+".dem" {
+						t.Fatalf("independent import %v path = %q", result.key, result.path)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatal("independent import did not return")
+				}
+			}
+		})
+	}
+}
+
+func TestImportCoordinatorWaiterCancelKeepsSharedTask(t *testing.T) {
+	c := newPlatformImportCoordinator()
+	key := testPlatformImportKey("g161-20260427162329954189731")
+
+	var runs int32
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	fn := func(context.Context) (string, error) {
+		atomic.AddInt32(&runs, 1)
+		close(entered)
+		<-release
+		return "shared.dem", nil
+	}
+
+	type outcome struct {
+		path string
+		err  error
+	}
+	ownerResult := make(chan outcome, 1)
+	go func() {
+		path, _, err := c.do(context.Background(), context.Background(), key, fn)
+		ownerResult <- outcome{path: path, err: err}
+	}()
+	<-entered
+
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, ranImport, err := c.do(context.Background(), waiterCtx, key, fn)
+		if ranImport {
+			waiterErr <- errors.New("cancelled waiter performed the real import")
+			return
+		}
+		waiterErr <- err
+	}()
+	waitForImportWaiters(t, c, key, 1)
+	cancelWaiter()
+	select {
+	case err := <-waiterErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancelled waiter error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled waiter did not return")
+	}
+
+	// The shared task is still running and a later waiter still receives its
+	// result; canceling one waiter only removed that waiter.
+	survivor := make(chan outcome, 1)
+	go func() {
+		path, _, err := c.do(context.Background(), context.Background(), key, fn)
+		survivor <- outcome{path: path, err: err}
+	}()
+	waitForImportWaiters(t, c, key, 1)
+	close(release)
+
+	for name, ch := range map[string]chan outcome{"surviving waiter": survivor, "real import": ownerResult} {
+		select {
+		case result := <-ch:
+			if result.err != nil || result.path != "shared.dem" {
+				t.Fatalf("%s = (%q, %v), want (%q, nil)", name, result.path, result.err, "shared.dem")
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s did not receive the shared result", name)
+		}
+	}
+	if got := atomic.LoadInt32(&runs); got != 1 {
+		t.Fatalf("real import runs = %d, want 1", got)
+	}
+}
+
+func TestImportCoordinatorSharesFrozenFailure(t *testing.T) {
+	c := newPlatformImportCoordinator()
+	key := testPlatformImportKey("g161-20260427162329954189731")
+	boom := errors.New("download failed")
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	fn := func(context.Context) (string, error) {
+		close(entered)
+		<-release
+		return "", boom
+	}
+
+	errs := make(chan error, 2)
+	go func() {
+		_, _, err := c.do(context.Background(), context.Background(), key, fn)
+		errs <- err
+	}()
+	<-entered
+	go func() {
+		_, _, err := c.do(context.Background(), context.Background(), key, fn)
+		errs <- err
+	}()
+	waitForImportWaiters(t, c, key, 1)
+	close(release)
+
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-errs:
+			if !errors.Is(err, boom) {
+				t.Fatalf("shared failure = %v, want %v", err, boom)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("caller did not receive the shared failure")
+		}
+	}
+}
+
+func TestImportCoordinatorDoesNotCacheFailure(t *testing.T) {
+	c := newPlatformImportCoordinator()
+	key := testPlatformImportKey("g161-20260427162329954189731")
+	boom := errors.New("download failed")
+
+	var runs int32
+	fn := func(context.Context) (string, error) {
+		if atomic.AddInt32(&runs, 1) == 1 {
+			return "", boom
+		}
+		return "retry.dem", nil
+	}
+
+	path, ranImport, err := c.do(context.Background(), context.Background(), key, fn)
+	if !errors.Is(err, boom) || path != "" || !ranImport {
+		t.Fatalf("first call = (%q, %v, %v), want the real import failure", path, ranImport, err)
+	}
+	path, ranImport, err = c.do(context.Background(), context.Background(), key, fn)
+	if err != nil || path != "retry.dem" || !ranImport {
+		t.Fatalf("retry call = (%q, %v, %v), want a new real import", path, ranImport, err)
+	}
+	if got := atomic.LoadInt32(&runs); got != 2 {
+		t.Fatalf("real import runs = %d, want 2", got)
+	}
+}
+
+func TestImportCoordinatorWakesWaitersWhenTaskPanics(t *testing.T) {
+	c := newPlatformImportCoordinator()
+	key := testPlatformImportKey("g161-20260427162329954189731")
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	fn := func(context.Context) (string, error) {
+		close(entered)
+		<-release
+		panic("import exploded")
+	}
+
+	ownerPanicked := make(chan any, 1)
+	go func() {
+		defer func() { ownerPanicked <- recover() }()
+		_, _, _ = c.do(context.Background(), context.Background(), key, fn)
+	}()
+	<-entered
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, _, err := c.do(context.Background(), context.Background(), key, fn)
+		waiterErr <- err
+	}()
+	waitForImportWaiters(t, c, key, 1)
+	close(release)
+
+	if recovered := <-ownerPanicked; recovered == nil {
+		t.Fatal("panic did not propagate to the owning caller")
+	}
+	select {
+	case err := <-waiterErr:
+		if err == nil || !strings.Contains(err.Error(), "异常终止") {
+			t.Fatalf("waiter error = %v, want a reported task failure", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter hung after the shared task panicked")
+	}
+}

--- a/internal/app/platform_import_test.go
+++ b/internal/app/platform_import_test.go
@@ -1,0 +1,591 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"cs2-highlight-tool-v2/internal/download"
+	"cs2-highlight-tool-v2/internal/envsetup"
+	"cs2-highlight-tool-v2/internal/fivee"
+	"cs2-highlight-tool-v2/internal/wanmei"
+)
+
+const (
+	testImportFiveEMatchID   = "g161-20260427162329954189731"
+	testImportFiveEMatchIDB  = "g161-20260427162329954189732"
+	testImportWanmeiMatchID  = "9208138716569380236"
+	testImportWanmeiMatchIDB = "9208138716569380237"
+	testImportDemoContent    = "PBDEMS2\x00shared-import"
+)
+
+type platformImportCase struct {
+	name       string
+	platform   platformImportPlatform
+	cacheDir   string
+	matchA     string
+	matchB     string
+	importCall func(a *App, matchID string) ([]string, error)
+}
+
+func platformImportCases() []platformImportCase {
+	return []platformImportCase{
+		{
+			name:     "fivee",
+			platform: platformImportFiveE,
+			cacheDir: "5e",
+			matchA:   testImportFiveEMatchID,
+			matchB:   testImportFiveEMatchIDB,
+			importCall: func(a *App, matchID string) ([]string, error) {
+				return a.ImportFiveEMatch(matchID)
+			},
+		},
+		{
+			name:     "wanmei",
+			platform: platformImportWanmei,
+			cacheDir: "wanmei",
+			matchA:   testImportWanmeiMatchID,
+			matchB:   testImportWanmeiMatchIDB,
+			importCall: func(a *App, matchID string) ([]string, error) {
+				return a.ImportWanmeiMatch("PVP@" + matchID)
+			},
+		},
+	}
+}
+
+func (tc platformImportCase) cachePath(dataDir string, matchID string) string {
+	return filepath.Join(dataDir, "demo", tc.cacheDir, matchID, matchID+".dem")
+}
+
+// stubPlatformImportSeams installs deterministic platform seams for one test
+// and restores every package seam on cleanup. archiveURL is the URL handed to
+// the transfer layer; when empty each request returns a URL that embeds the
+// requested match ID so a stub can tell parallel matches apart. A nil
+// downloadFn selects the built-in download (used by the cancellation test).
+func stubPlatformImportSeams(
+	t *testing.T,
+	platform platformImportPlatform,
+	archiveURL string,
+	downloadFn func(url string, targetPath string, emitProgress download.ProgressFunc) error,
+	demContent []byte,
+) {
+	t.Helper()
+	unzipFn := func(ctx context.Context, archivePath string, destDir string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(destDir, 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(destDir, "inner.dem"), demContent, 0o644)
+	}
+
+	switch platform {
+	case platformImportFiveE:
+		oldReq := fivee.HTTPRequestFn
+		oldDownload := fivee.DownloadFileFn
+		oldUnzip := fivee.UnzipFn
+		oldFind := fivee.FindFirstByExtFn
+		oldCopy := fivee.CopyFileFn
+
+		fivee.HTTPRequestFn = func(req *http.Request, timeout time.Duration) (*http.Response, error) {
+			demoURL := strings.TrimSpace(archiveURL)
+			if demoURL == "" {
+				demoURL = "https://example.com/" + path.Base(req.URL.Path) + "_de_dust2.zip"
+			}
+			return stubFiveETestResponse(http.StatusOK, `{"data":{"main":{"demo_url":"`+demoURL+`"}}}`), nil
+		}
+		fivee.DownloadFileFn = downloadFn
+		fivee.UnzipFn = unzipFn
+		fivee.FindFirstByExtFn = download.FindFirstByExt
+		fivee.CopyFileFn = download.CopyFile
+		t.Cleanup(func() {
+			fivee.HTTPRequestFn = oldReq
+			fivee.DownloadFileFn = oldDownload
+			fivee.UnzipFn = oldUnzip
+			fivee.FindFirstByExtFn = oldFind
+			fivee.CopyFileFn = oldCopy
+		})
+	case platformImportWanmei:
+		oldReq := wanmei.HTTPRequestFn
+		oldResolve := wanmei.OSSResolveHTTPDoFn
+		oldDownload := wanmei.DownloadFileFn
+		oldUnzip := wanmei.UnzipFn
+		oldFind := wanmei.FindFirstByExtFn
+		oldCopy := wanmei.CopyFileFn
+
+		encodedToken := encodeWanmeiLogForTest("demo_token_1711111111_76561198051245123")
+		wanmei.HTTPRequestFn = func(req *http.Request, timeout time.Duration) (*http.Response, error) {
+			switch req.URL.String() {
+			case "http://127.0.0.1:55555/":
+				return stubWanmeiTestResponse(http.StatusOK, fmt.Sprintf(`{"nickname":"alice","token":"%s"}`, encodedToken)), nil
+			case "https://api-ipv4.ip.sb/ip":
+				return stubWanmeiTestResponse(http.StatusOK, "1.2.3.4"), nil
+			default:
+				return nil, fmt.Errorf("unexpected wanmei HTTP request: %s", req.URL.String())
+			}
+		}
+		wanmei.OSSResolveHTTPDoFn = func(req *http.Request, timeout time.Duration) (*http.Response, error) {
+			location := strings.TrimSpace(archiveURL)
+			if location == "" {
+				location = "https://oss.example.com/" + req.URL.Query().Get("match_id") + "_0.zip"
+			}
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{location}},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}
+		wanmei.DownloadFileFn = downloadFn
+		wanmei.UnzipFn = unzipFn
+		wanmei.FindFirstByExtFn = download.FindFirstByExt
+		wanmei.CopyFileFn = download.CopyFile
+		t.Cleanup(func() {
+			wanmei.HTTPRequestFn = oldReq
+			wanmei.OSSResolveHTTPDoFn = oldResolve
+			wanmei.DownloadFileFn = oldDownload
+			wanmei.UnzipFn = oldUnzip
+			wanmei.FindFirstByExtFn = oldFind
+			wanmei.CopyFileFn = oldCopy
+		})
+	default:
+		t.Fatalf("unknown platform %q", platform)
+	}
+}
+
+func assertNoImportStagingLeftovers(t *testing.T, cacheRoot string) {
+	t.Helper()
+	entries, err := os.ReadDir(cacheRoot)
+	if err != nil {
+		t.Fatalf("read cache root %q: %v", cacheRoot, err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".5e-import-") || strings.HasPrefix(entry.Name(), ".wanmei-import-") {
+			t.Fatalf("import staging directory was not cleaned up: %s", entry.Name())
+		}
+	}
+}
+
+func TestImportSameMatchSharesOneDownload(t *testing.T) {
+	for _, tc := range platformImportCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			a := newWorkspaceLifecycleTestApp(t, dataDir)
+
+			var downloadCalls int32
+			downloadStarted := make(chan struct{})
+			releaseDownload := make(chan struct{})
+			stubPlatformImportSeams(t, tc.platform, "", func(url string, targetPath string, emitProgress download.ProgressFunc) error {
+				if atomic.AddInt32(&downloadCalls, 1) == 1 {
+					close(downloadStarted)
+				}
+				<-releaseDownload
+				return os.WriteFile(targetPath, []byte("zip"), 0o644)
+			}, []byte(testImportDemoContent))
+
+			type outcome struct {
+				paths []string
+				err   error
+			}
+			results := make(chan outcome, 2)
+			startImport := func() {
+				go func() {
+					paths, err := tc.importCall(a, tc.matchA)
+					results <- outcome{paths: paths, err: err}
+				}()
+			}
+
+			startImport()
+			select {
+			case <-downloadStarted:
+			case <-time.After(5 * time.Second):
+				t.Fatal("first import never started its download")
+			}
+			startImport()
+			// The shared task is already inside the download, so the second
+			// caller can only be waiting for the same result.
+			waitForImportWaiters(t, a.importCoordinator(), platformImportKey{platform: tc.platform, matchID: tc.matchA}, 1)
+			close(releaseDownload)
+
+			wantPath := tc.cachePath(dataDir, tc.matchA)
+			for i := 0; i < 2; i++ {
+				select {
+				case result := <-results:
+					if result.err != nil {
+						t.Fatalf("import error: %v", result.err)
+					}
+					if len(result.paths) != 1 || result.paths[0] != wantPath {
+						t.Fatalf("import paths = %v, want [%q]", result.paths, wantPath)
+					}
+				case <-time.After(5 * time.Second):
+					t.Fatal("import did not return")
+				}
+			}
+			if got := atomic.LoadInt32(&downloadCalls); got != 1 {
+				t.Fatalf("download calls = %d, want 1 shared download", got)
+			}
+			content, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatalf("read cached demo: %v", err)
+			}
+			if string(content) != testImportDemoContent {
+				t.Fatalf("cached demo content = %q, want %q", string(content), testImportDemoContent)
+			}
+			assertNoImportStagingLeftovers(t, filepath.Dir(wantPath))
+		})
+	}
+}
+
+func TestImportFailureCanBeRetried(t *testing.T) {
+	for _, tc := range platformImportCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			a := newWorkspaceLifecycleTestApp(t, dataDir)
+
+			var downloadCalls int32
+			boom := errors.New("injected download failure")
+			stubPlatformImportSeams(t, tc.platform, "", func(url string, targetPath string, emitProgress download.ProgressFunc) error {
+				if atomic.AddInt32(&downloadCalls, 1) == 1 {
+					return boom
+				}
+				return os.WriteFile(targetPath, []byte("zip"), 0o644)
+			}, []byte(testImportDemoContent))
+
+			if _, err := tc.importCall(a, tc.matchA); err == nil {
+				t.Fatal("first import should fail")
+			}
+			wantPath := tc.cachePath(dataDir, tc.matchA)
+			if _, err := os.Stat(wantPath); !os.IsNotExist(err) {
+				t.Fatalf("failed import left a cache file, stat err=%v", err)
+			}
+			assertNoImportStagingLeftovers(t, filepath.Dir(wantPath))
+
+			paths, err := tc.importCall(a, tc.matchA)
+			if err != nil {
+				t.Fatalf("retry import error: %v", err)
+			}
+			if len(paths) != 1 || paths[0] != wantPath {
+				t.Fatalf("retry paths = %v, want [%q]", paths, wantPath)
+			}
+			if got := atomic.LoadInt32(&downloadCalls); got != 2 {
+				t.Fatalf("download calls = %d, want 2 (failures must not be cached)", got)
+			}
+			content, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatalf("read retried demo: %v", err)
+			}
+			if string(content) != testImportDemoContent {
+				t.Fatalf("retried demo content = %q, want %q", string(content), testImportDemoContent)
+			}
+		})
+	}
+}
+
+func TestImportDifferentMatchesRunInParallel(t *testing.T) {
+	for _, tc := range platformImportCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			a := newWorkspaceLifecycleTestApp(t, dataDir)
+
+			entered := make(chan string, 2)
+			release := make(chan struct{})
+			stubPlatformImportSeams(t, tc.platform, "", func(url string, targetPath string, emitProgress download.ProgressFunc) error {
+				entered <- filepath.Dir(targetPath)
+				<-release
+				return os.WriteFile(targetPath, []byte("zip"), 0o644)
+			}, []byte(testImportDemoContent))
+
+			type outcome struct {
+				matchID string
+				paths   []string
+				err     error
+			}
+			results := make(chan outcome, 2)
+			for _, matchID := range []string{tc.matchA, tc.matchB} {
+				matchID := matchID
+				go func() {
+					paths, err := tc.importCall(a, matchID)
+					results <- outcome{matchID: matchID, paths: paths, err: err}
+				}()
+			}
+
+			stagingDirs := make(map[string]struct{}, 2)
+			for i := 0; i < 2; i++ {
+				select {
+				case dir := <-entered:
+					stagingDirs[dir] = struct{}{}
+				case <-time.After(5 * time.Second):
+					t.Fatalf("different matches did not download in parallel, saw %v", stagingDirs)
+				}
+			}
+			if len(stagingDirs) != 2 {
+				t.Fatalf("parallel imports reused one archive/extract directory: %v", stagingDirs)
+			}
+			for dir := range stagingDirs {
+				if _, err := os.Stat(dir); err != nil {
+					t.Fatalf("staging directory %q missing while both imports run: %v", dir, err)
+				}
+			}
+			close(release)
+
+			for i := 0; i < 2; i++ {
+				select {
+				case result := <-results:
+					if result.err != nil {
+						t.Fatalf("import %s error: %v", result.matchID, result.err)
+					}
+					wantPath := tc.cachePath(dataDir, result.matchID)
+					if len(result.paths) != 1 || result.paths[0] != wantPath {
+						t.Fatalf("import %s paths = %v, want [%q]", result.matchID, result.paths, wantPath)
+					}
+				case <-time.After(5 * time.Second):
+					t.Fatal("parallel import did not return")
+				}
+			}
+			for _, matchID := range []string{tc.matchA, tc.matchB} {
+				wantPath := tc.cachePath(dataDir, matchID)
+				content, err := os.ReadFile(wantPath)
+				if err != nil {
+					t.Fatalf("read parallel demo %s: %v", matchID, err)
+				}
+				if string(content) != testImportDemoContent {
+					t.Fatalf("parallel demo %s content = %q", matchID, string(content))
+				}
+				assertNoImportStagingLeftovers(t, filepath.Dir(wantPath))
+			}
+		})
+	}
+}
+
+func TestImportFailureDoesNotDisturbParallelImport(t *testing.T) {
+	for _, tc := range platformImportCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			a := newWorkspaceLifecycleTestApp(t, dataDir)
+
+			entered := make(chan string, 2)
+			release := make(chan struct{})
+			boom := errors.New("injected download failure")
+			stubPlatformImportSeams(t, tc.platform, "", func(url string, targetPath string, emitProgress download.ProgressFunc) error {
+				entered <- filepath.Dir(targetPath)
+				<-release
+				if strings.Contains(filepath.Base(targetPath), tc.matchA) {
+					return boom
+				}
+				return os.WriteFile(targetPath, []byte("zip"), 0o644)
+			}, []byte(testImportDemoContent))
+
+			type outcome struct {
+				matchID string
+				err     error
+			}
+			results := make(chan outcome, 2)
+			for _, matchID := range []string{tc.matchA, tc.matchB} {
+				matchID := matchID
+				go func() {
+					_, err := tc.importCall(a, matchID)
+					results <- outcome{matchID: matchID, err: err}
+				}()
+			}
+			for i := 0; i < 2; i++ {
+				select {
+				case <-entered:
+				case <-time.After(5 * time.Second):
+					t.Fatal("parallel downloads did not both start")
+				}
+			}
+			close(release)
+
+			for i := 0; i < 2; i++ {
+				select {
+				case result := <-results:
+					if result.matchID == tc.matchA && result.err == nil {
+						t.Fatal("failing import unexpectedly succeeded")
+					}
+					if result.matchID == tc.matchB && result.err != nil {
+						t.Fatalf("sibling import failed because of the other match: %v", result.err)
+					}
+				case <-time.After(5 * time.Second):
+					t.Fatal("parallel import did not return")
+				}
+			}
+
+			failedPath := tc.cachePath(dataDir, tc.matchA)
+			if _, err := os.Stat(failedPath); !os.IsNotExist(err) {
+				t.Fatalf("failed import left a cache file, stat err=%v", err)
+			}
+			assertNoImportStagingLeftovers(t, filepath.Dir(failedPath))
+			siblingPath := tc.cachePath(dataDir, tc.matchB)
+			content, err := os.ReadFile(siblingPath)
+			if err != nil {
+				t.Fatalf("sibling demo was disturbed: %v", err)
+			}
+			if string(content) != testImportDemoContent {
+				t.Fatalf("sibling demo content = %q, want %q", string(content), testImportDemoContent)
+			}
+			assertNoImportStagingLeftovers(t, filepath.Dir(siblingPath))
+		})
+	}
+}
+
+func TestImportAbortsWhenWorkspaceCloses(t *testing.T) {
+	for _, tc := range platformImportCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			a := newWorkspaceLifecycleTestApp(t, dataDir)
+
+			var startOnce sync.Once
+			downloadStarted := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Length", "1048576")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(bytes.Repeat([]byte("d"), 4096))
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+				startOnce.Do(func() { close(downloadStarted) })
+				<-r.Context().Done()
+			}))
+			defer server.Close()
+
+			// nil selects the built-in context-aware download so the workspace
+			// cancellation really reaches the transfer.
+			stubPlatformImportSeams(t, tc.platform, server.URL+"/demo.zip", nil, []byte(testImportDemoContent))
+
+			errCh := make(chan error, 1)
+			go func() {
+				_, err := tc.importCall(a, tc.matchA)
+				errCh <- err
+			}()
+			select {
+			case <-downloadStarted:
+			case <-time.After(5 * time.Second):
+				t.Fatal("download never started")
+			}
+
+			session := a.workspaceSnapshot().session
+			if session == nil {
+				t.Fatal("test app has no workspace session")
+			}
+			stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := session.close(stopCtx); err != nil {
+				t.Fatalf("session.close did not wait for the import task: %v", err)
+			}
+
+			select {
+			case err := <-errCh:
+				if err == nil {
+					t.Fatal("import succeeded after workspace close")
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("import task did not stop after workspace close")
+			}
+			wantPath := tc.cachePath(dataDir, tc.matchA)
+			if _, err := os.Stat(wantPath); !os.IsNotExist(err) {
+				t.Fatalf("canceled import committed a cache file, stat err=%v", err)
+			}
+			assertNoImportStagingLeftovers(t, filepath.Dir(wantPath))
+		})
+	}
+}
+
+func TestImportAbortsWhenWorkspaceClosesDuringExtraction(t *testing.T) {
+	for _, tc := range platformImportCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			a := newWorkspaceLifecycleTestApp(t, dataDir)
+
+			var startOnce sync.Once
+			extractionStarted := make(chan struct{})
+			blockingExtraction := func(ctx context.Context, archivePath string, destDir string) error {
+				if err := os.MkdirAll(destDir, 0o755); err != nil {
+					return err
+				}
+				if err := os.WriteFile(filepath.Join(destDir, "partial.dem"), []byte("partial"), 0o644); err != nil {
+					return err
+				}
+				startOnce.Do(func() { close(extractionStarted) })
+				<-ctx.Done()
+				return ctx.Err()
+			}
+
+			stubPlatformImportSeams(t, tc.platform, "", func(url string, targetPath string, emitProgress download.ProgressFunc) error {
+				return os.WriteFile(targetPath, []byte("zip"), 0o644)
+			}, []byte(testImportDemoContent))
+			// Override the extraction seam for this test only; the helper's
+			// cleanup still restores the package default.
+			switch tc.platform {
+			case platformImportFiveE:
+				fivee.UnzipFn = blockingExtraction
+			case platformImportWanmei:
+				wanmei.UnzipFn = blockingExtraction
+			default:
+				t.Fatalf("unknown platform %q", tc.platform)
+			}
+
+			errCh := make(chan error, 1)
+			go func() {
+				_, err := tc.importCall(a, tc.matchA)
+				errCh <- err
+			}()
+			select {
+			case <-extractionStarted:
+			case <-time.After(5 * time.Second):
+				t.Fatal("extraction never started")
+			}
+
+			session := a.workspaceSnapshot().session
+			if session == nil {
+				t.Fatal("test app has no workspace session")
+			}
+			stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := session.close(stopCtx); err != nil {
+				t.Fatalf("session.close did not interrupt the extraction: %v", err)
+			}
+
+			select {
+			case err := <-errCh:
+				if err == nil {
+					t.Fatal("import succeeded after workspace close during extraction")
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("import task did not stop after workspace close")
+			}
+			wantPath := tc.cachePath(dataDir, tc.matchA)
+			if _, err := os.Stat(wantPath); !os.IsNotExist(err) {
+				t.Fatalf("canceled extraction committed a cache file, stat err=%v", err)
+			}
+			assertNoImportStagingLeftovers(t, filepath.Dir(wantPath))
+		})
+	}
+}
+
+func TestWorkspaceInstallReplacesImportCoordinator(t *testing.T) {
+	dataDir := t.TempDir()
+	a := newWorkspaceLifecycleTestApp(t, dataDir)
+	first := a.importCoordinator()
+
+	newRoot := t.TempDir()
+	svc := envsetup.NewWithDataDir(t.TempDir(), newRoot, "test")
+	a.serviceMu.Lock()
+	a.installWorkspaceLocked(newRoot, svc)
+	a.serviceMu.Unlock()
+
+	if a.importCoordinator() == first {
+		t.Fatal("a new workspace identity reused the previous import coordinator")
+	}
+}

--- a/internal/app/work_activity.go
+++ b/internal/app/work_activity.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"sync"
@@ -128,15 +129,27 @@ func (a *App) managedWorkspaceRoot() string {
 // of one operation. The reservation prevents ResetWorkspace from changing
 // dataDir while the caller is doing I/O.
 func (a *App) beginManagedWorkspaceUse() (func(), string, error) {
+	_, release, dataDir, err := a.beginManagedWorkspaceTaskUse()
+	return release, dataDir, err
+}
+
+// beginManagedWorkspaceTaskUse is beginManagedWorkspaceUse plus the lifecycle
+// context of the workspace the reservation belongs to. Work that several
+// callers await (for example one shared platform demo import) must run under
+// this context instead of a caller context: one caller leaving must not cancel
+// a task the other callers still expect a result from. The context is only
+// canceled when the workspace session closes, and the reservation itself is
+// held until the real task exits.
+func (a *App) beginManagedWorkspaceTaskUse() (context.Context, func(), string, error) {
 	if a == nil {
-		return nil, "", workspaceNotInitializedErr()
+		return nil, nil, "", workspaceNotInitializedErr()
 	}
 	session := a.ensureWorkspaceSession()
 	snapshot := a.workspaceSnapshot()
 	a.managedFilesMu.Lock()
 	if a.managedFilesClearing {
 		a.managedFilesMu.Unlock()
-		return nil, "", fmt.Errorf("正在清理目录，请完成后再试")
+		return nil, nil, "", fmt.Errorf("正在清理目录，请完成后再试")
 	}
 	dataDir := snapshot.root
 	if session != nil {
@@ -146,25 +159,28 @@ func (a *App) beginManagedWorkspaceUse() (func(), string, error) {
 	}
 	if dataDir == "" {
 		a.managedFilesMu.Unlock()
-		return nil, "", workspaceNotInitializedErr()
+		return nil, nil, "", workspaceNotInitializedErr()
 	}
+	workCtx := context.Background()
 	var releaseSession func()
 	if session != nil {
-		var ok bool
-		_, releaseSession, ok = session.beginTask()
+		sessionCtx, release, ok := session.beginTask()
 		if !ok {
 			a.managedFilesMu.Unlock()
-			return nil, "", fmt.Errorf("工作目录正在关闭，请完成后再试")
+			return nil, nil, "", fmt.Errorf("工作目录正在关闭，请完成后再试")
 		}
+		workCtx = sessionCtx
+		releaseSession = release
 	}
 	releaseManaged := a.reserveManagedResourceLocked()
 	a.managedFilesMu.Unlock()
-	return func() {
+	release := func() {
 		if releaseSession != nil {
 			releaseSession()
 		}
 		releaseManaged()
-	}, dataDir, nil
+	}
+	return workCtx, release, dataDir, nil
 }
 
 // Reserve file use without holding a state mutex over I/O. Imports, parsing,

--- a/internal/app/workspace_session.go
+++ b/internal/app/workspace_session.go
@@ -260,6 +260,9 @@ func (a *App) installWorkspaceLocked(root string, service *envsetup.Service) *wo
 	a.workspaceResetPendingPath = ""
 	a.workspaceResetRegistryPending = false
 	a.workspaceResetCompleted = false
+	// A new workspace identity must not reuse in-flight import tasks from the
+	// previous one; the coordinator is recreated lazily on the next import.
+	a.platformImports = nil
 	return session
 }
 

--- a/internal/download/archive.go
+++ b/internal/download/archive.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"archive/zip"
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -12,7 +13,51 @@ import (
 	"github.com/bodgit/sevenzip"
 )
 
+// unzipOps is an instance dependency for deterministic cancellation tests.
+// It deliberately mirrors the replaceDirFS pattern instead of adding a
+// package-level writable seam.
+type unzipOps struct {
+	openEntry func(*zip.File) (io.ReadCloser, error)
+}
+
+func defaultUnzipOps() unzipOps {
+	return unzipOps{
+		openEntry: func(f *zip.File) (io.ReadCloser, error) { return f.Open() },
+	}
+}
+
+func (ops unzipOps) withDefaults() unzipOps {
+	if ops.openEntry == nil {
+		ops.openEntry = defaultUnzipOps().openEntry
+	}
+	return ops
+}
+
+// Unzip is the compatibility entry point for callers without a cancellation
+// context. Callers that own a workspace lifecycle use UnzipWithContext.
 func Unzip(zipPath, destDir string) error {
+	return unzipWithContext(context.Background(), zipPath, destDir, defaultUnzipOps())
+}
+
+// UnzipWithContext extracts zipPath into destDir and honors ctx. Cancellation
+// is checked before the archive is opened, before every entry, and during
+// every file copy, so closing a workspace stops a large extraction instead of
+// waiting for the whole archive to be written into staging. A canceled
+// extraction may leave partial files inside destDir; callers that own a
+// private staging directory remove it themselves.
+func UnzipWithContext(ctx context.Context, zipPath, destDir string) error {
+	return unzipWithContext(ctx, zipPath, destDir, defaultUnzipOps())
+}
+
+func unzipWithContext(ctx context.Context, zipPath, destDir string, ops unzipOps) error {
+	ops = ops.withDefaults()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := contextErr(ctx); err != nil {
+		return err
+	}
+
 	r, err := zip.OpenReader(zipPath)
 	if err != nil {
 		return err
@@ -20,6 +65,9 @@ func Unzip(zipPath, destDir string) error {
 	defer r.Close()
 	destClean := filepath.Clean(destDir) + string(os.PathSeparator)
 	for _, f := range r.File {
+		if err := contextErr(ctx); err != nil {
+			return err
+		}
 		target := filepath.Join(destDir, f.Name)
 		if !strings.HasPrefix(filepath.Clean(target)+pathSuffix(f.FileInfo().IsDir()), destClean) {
 			return fmt.Errorf("压缩包包含非法路径: %s", f.Name)
@@ -37,19 +85,19 @@ func Unzip(zipPath, destDir string) error {
 		if err != nil {
 			return err
 		}
-		rc, err := f.Open()
+		rc, err := ops.openEntry(f)
 		if err != nil {
 			out.Close()
 			return err
 		}
-		_, copyErr := io.Copy(out, rc)
+		_, copyErr := io.Copy(out, contextReader{ctx: ctx, reader: rc})
 		rc.Close()
 		out.Close()
 		if copyErr != nil {
 			return copyErr
 		}
 	}
-	return nil
+	return contextErr(ctx)
 }
 
 func Extract7z(archivePath, destDir string) error {

--- a/internal/download/archive.go
+++ b/internal/download/archive.go
@@ -141,26 +141,287 @@ func CopyDirContents(src, dst string) error {
 	})
 }
 
+// ReplaceDirPhase identifies the point at which a directory replacement
+// stopped.  The phases intentionally mirror the install commit table: the
+// source is prepared first, the old target is backed up, the new target is
+// committed, and cleanup is last.
+type ReplaceDirPhase string
+
+const (
+	ReplaceDirPhasePrepare ReplaceDirPhase = "prepare"
+	ReplaceDirPhaseBackup  ReplaceDirPhase = "backup"
+	ReplaceDirPhaseCommit  ReplaceDirPhase = "commit"
+	ReplaceDirPhaseRestore ReplaceDirPhase = "restore"
+	ReplaceDirPhaseCleanup ReplaceDirPhase = "cleanup"
+)
+
+// ReplaceDirReport describes the paths owned by one replacement attempt.
+// StagingPath and BackupPath are retained in the report even after a
+// successful cleanup so callers can include the paths in diagnostics.
+// BackupCleanupError is a warning: the new target has already been committed
+// and the backup is deliberately left in place for recovery.
+type ReplaceDirReport struct {
+	TargetPath         string
+	StagingPath        string
+	BackupPath         string
+	HadExistingTarget  bool
+	Committed          bool
+	Recovered          bool
+	Phase              ReplaceDirPhase
+	BackupCleanupError error
+}
+
+// ReplaceDirError is returned when the new directory could not be committed
+// (or the old directory could not be prepared for the commit).  Primary and
+// Recovery are kept separate so callers and tests can inspect both failures.
+// The staging/backup paths identify the only paths created by this attempt;
+// pre-existing recovery directories are never removed by this helper.
+type ReplaceDirError struct {
+	Phase       ReplaceDirPhase
+	TargetPath  string
+	StagingPath string
+	BackupPath  string
+	Primary     error
+	Recovery    error
+	Recovered   bool
+}
+
+func (e *ReplaceDirError) Error() string {
+	if e == nil {
+		return "目录替换失败"
+	}
+	message := fmt.Sprintf("目录替换在 %s 阶段失败", e.Phase)
+	if e.Primary != nil {
+		message += ": " + e.Primary.Error()
+	}
+	if e.Recovery != nil {
+		message += "; 恢复/清理失败: " + e.Recovery.Error()
+	}
+	if e.Recovered {
+		message += "; 旧版本已恢复"
+	}
+	if e.StagingPath != "" {
+		message += "; staging=" + e.StagingPath
+	}
+	if e.BackupPath != "" {
+		message += "; backup=" + e.BackupPath
+	}
+	return message
+}
+
+// Unwrap exposes both the operation error and a possible recovery/cleanup
+// error to errors.Is/errors.As without losing the primary failure.
+func (e *ReplaceDirError) Unwrap() []error {
+	if e == nil {
+		return nil
+	}
+	result := make([]error, 0, 2)
+	if e.Primary != nil {
+		result = append(result, e.Primary)
+	}
+	if e.Recovery != nil {
+		result = append(result, e.Recovery)
+	}
+	return result
+}
+
+// replaceDirFS is an instance dependency for the filesystem transaction.
+// Keeping the seam on an instance avoids package-global mutable hooks while
+// still allowing deterministic rename/copy/cleanup fault injection in tests.
+type replaceDirFS struct {
+	stat            func(string) (os.FileInfo, error)
+	mkdirAll        func(string, os.FileMode) error
+	mkdirTemp       func(string, string) (string, error)
+	rename          func(string, string) error
+	removeAll       func(string) error
+	copyDirContents func(string, string) error
+}
+
+func defaultReplaceDirFS() replaceDirFS {
+	return replaceDirFS{
+		stat:            os.Lstat,
+		mkdirAll:        os.MkdirAll,
+		mkdirTemp:       os.MkdirTemp,
+		rename:          os.Rename,
+		removeAll:       os.RemoveAll,
+		copyDirContents: CopyDirContents,
+	}
+}
+
+func (ops replaceDirFS) withDefaults() replaceDirFS {
+	defaults := defaultReplaceDirFS()
+	if ops.stat == nil {
+		ops.stat = defaults.stat
+	}
+	if ops.mkdirAll == nil {
+		ops.mkdirAll = defaults.mkdirAll
+	}
+	if ops.mkdirTemp == nil {
+		ops.mkdirTemp = defaults.mkdirTemp
+	}
+	if ops.rename == nil {
+		ops.rename = defaults.rename
+	}
+	if ops.removeAll == nil {
+		ops.removeAll = defaults.removeAll
+	}
+	if ops.copyDirContents == nil {
+		ops.copyDirContents = defaults.copyDirContents
+	}
+	return ops
+}
+
+func replaceDirError(report ReplaceDirReport, phase ReplaceDirPhase, primary, recovery error) error {
+	return &ReplaceDirError{
+		Phase:       phase,
+		TargetPath:  report.TargetPath,
+		StagingPath: report.StagingPath,
+		BackupPath:  report.BackupPath,
+		Primary:     primary,
+		Recovery:    recovery,
+		Recovered:   report.Recovered,
+	}
+}
+
+// ReplaceDirWithContentsWithReport runs the directory replacement and
+// returns a report suitable for structured logging.  A backup cleanup error
+// is reported in the result but does not turn a committed installation into a
+// failed installation; the backup remains available for manual recovery.
+func ReplaceDirWithContentsWithReport(src, dst string) (ReplaceDirReport, error) {
+	return replaceDirWithContents(defaultReplaceDirFS(), src, dst)
+}
+
 func ReplaceDirWithContents(src, dst string) error {
-	backup := dst + ".old"
-	_ = os.RemoveAll(backup)
-	if _, err := os.Stat(dst); err == nil {
-		if err := os.Rename(dst, backup); err != nil {
-			if err := os.RemoveAll(dst); err != nil {
-				return err
-			}
+	_, err := ReplaceDirWithContentsWithReport(src, dst)
+	return err
+}
+
+func replaceDirWithContents(ops replaceDirFS, src, dst string) (ReplaceDirReport, error) {
+	ops = ops.withDefaults()
+	report := ReplaceDirReport{
+		TargetPath: filepath.Clean(dst),
+		Phase:      ReplaceDirPhasePrepare,
+	}
+
+	if src == "" {
+		return report, replaceDirError(report, ReplaceDirPhasePrepare, fmt.Errorf("源目录为空"), nil)
+	}
+	if dst == "" {
+		return report, replaceDirError(report, ReplaceDirPhasePrepare, fmt.Errorf("目标目录为空"), nil)
+	}
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+	report.TargetPath = dst
+
+	sourceInfo, err := ops.stat(src)
+	if err != nil {
+		return report, replaceDirError(report, ReplaceDirPhasePrepare, fmt.Errorf("读取源目录失败: %w", err), nil)
+	}
+	if !sourceInfo.IsDir() {
+		return report, replaceDirError(report, ReplaceDirPhasePrepare, fmt.Errorf("源路径不是目录: %s", src), nil)
+	}
+
+	parent := filepath.Dir(dst)
+	if err := ops.mkdirAll(parent, 0755); err != nil {
+		return report, replaceDirError(report, ReplaceDirPhasePrepare, fmt.Errorf("创建目标父目录失败: %w", err), nil)
+	}
+
+	staging, err := ops.mkdirTemp(parent, "."+filepath.Base(dst)+".staging-")
+	if err != nil {
+		return report, replaceDirError(report, ReplaceDirPhasePrepare, fmt.Errorf("创建 staging 目录失败: %w", err), nil)
+	}
+	report.StagingPath = staging
+
+	cleanupStaging := func(phase ReplaceDirPhase, primary error) (ReplaceDirReport, error) {
+		if cleanupErr := ops.removeAll(staging); cleanupErr != nil {
+			return report, replaceDirError(report, phase, primary,
+				fmt.Errorf("清理 staging %q 失败: %w", staging, cleanupErr))
+		}
+		return report, replaceDirError(report, phase, primary, nil)
+	}
+
+	if err := ops.copyDirContents(src, staging); err != nil {
+		return cleanupStaging(ReplaceDirPhasePrepare, fmt.Errorf("准备新内容失败: %w", err))
+	}
+	stagingInfo, err := ops.stat(staging)
+	if err != nil {
+		return cleanupStaging(ReplaceDirPhasePrepare, fmt.Errorf("验证 staging 目录失败: %w", err))
+	}
+	if !stagingInfo.IsDir() {
+		return cleanupStaging(ReplaceDirPhasePrepare, fmt.Errorf("staging 路径不是目录: %s", staging))
+	}
+
+	report.Phase = ReplaceDirPhaseBackup
+	_, err = ops.stat(dst)
+	hasTarget := true
+	if err != nil {
+		if os.IsNotExist(err) {
+			hasTarget = false
+		} else {
+			return cleanupStaging(ReplaceDirPhaseBackup, fmt.Errorf("读取旧目标失败: %w", err))
 		}
 	}
-	if err := os.MkdirAll(dst, 0755); err != nil {
-		return err
+	report.HadExistingTarget = hasTarget
+
+	if !hasTarget {
+		report.Phase = ReplaceDirPhaseCommit
+		if err := ops.rename(staging, dst); err != nil {
+			// There is no old target to restore. Keep the staging directory for
+			// diagnostics/retry and never remove an unrelated path.
+			return report, replaceDirError(report, ReplaceDirPhaseCommit,
+				fmt.Errorf("提交新目录失败: %w", err), nil)
+		}
+		report.Committed = true
+		report.Phase = ReplaceDirPhaseCleanup
+		return report, nil
 	}
-	if err := CopyDirContents(src, dst); err != nil {
-		_ = os.RemoveAll(dst)
-		_ = os.Rename(backup, dst)
-		return err
+
+	// Create a unique, currently empty backup name. The placeholder is ours;
+	// any pre-existing .old or transaction directory is intentionally left
+	// untouched because it may be the only recovery source from an older run.
+	backup, err := ops.mkdirTemp(parent, "."+filepath.Base(dst)+".backup-")
+	if err != nil {
+		return cleanupStaging(ReplaceDirPhaseBackup, fmt.Errorf("创建 backup 目录失败: %w", err))
 	}
-	_ = os.RemoveAll(backup)
-	return nil
+	report.BackupPath = backup
+	if err := ops.removeAll(backup); err != nil {
+		// The backup placeholder is still ours, so it is deliberately retained
+		// when its cleanup fails. Do not touch the old target.
+		return cleanupStaging(ReplaceDirPhaseBackup, fmt.Errorf("准备 backup 目录失败: %w", err))
+	}
+	if err := ops.rename(dst, backup); err != nil {
+		// A failed backup rename leaves dst as the valid old version. The old
+		// implementation removed dst here; that is explicitly forbidden.
+		return cleanupStaging(ReplaceDirPhaseBackup, fmt.Errorf("备份旧目录失败: %w", err))
+	}
+
+	report.Phase = ReplaceDirPhaseCommit
+	if err := ops.rename(staging, dst); err != nil {
+		commitErr := fmt.Errorf("提交新目录失败: %w", err)
+		report.Phase = ReplaceDirPhaseRestore
+		restoreErr := ops.rename(backup, dst)
+		if restoreErr == nil {
+			report.Recovered = true
+			report.Phase = ReplaceDirPhaseCommit
+			return report, replaceDirError(report, ReplaceDirPhaseCommit, commitErr, nil)
+		}
+		// Both paths remain in place. In particular, do not remove staging or
+		// backup after a failed recovery: one of them may be needed for manual
+		// repair or the next startup.
+		return report, replaceDirError(report, ReplaceDirPhaseRestore, commitErr,
+			fmt.Errorf("恢复旧目录失败: %w", restoreErr))
+	}
+
+	report.Committed = true
+	report.Phase = ReplaceDirPhaseCleanup
+	if err := ops.removeAll(backup); err != nil {
+		// The new target is already live. Keep backup and report it as a warning
+		// instead of returning an installation error that could trigger a
+		// destructive retry.
+		report.BackupCleanupError = fmt.Errorf("清理旧版本 backup %q 失败: %w", backup, err)
+		return report, nil
+	}
+	return report, nil
 }
 
 func FindFile(root, nameLower string) (string, error) {

--- a/internal/download/archive.go
+++ b/internal/download/archive.go
@@ -99,28 +99,6 @@ func pathSuffix(isDir bool) string {
 	return ""
 }
 
-func CopyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-	info, err := in.Stat()
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
-		return err
-	}
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-	_, err = io.Copy(out, in)
-	return err
-}
-
 func CopyDirContents(src, dst string) error {
 	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {

--- a/internal/download/archive_test.go
+++ b/internal/download/archive_test.go
@@ -1,0 +1,304 @@
+package download
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestFile(t *testing.T, root, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func TestReplaceDirWithContentsCommitsNewContentAndPreservesUnknownResidue(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "component")
+	writeTestFile(t, src, "bin/tool.exe", "new")
+	writeTestFile(t, dst, "bin/tool.exe", "old")
+	stale := filepath.Join(root, "component.old")
+	writeTestFile(t, stale, "recovery-marker", "leave-me")
+
+	report, err := replaceDirWithContents(defaultReplaceDirFS(), src, dst)
+	if err != nil {
+		t.Fatalf("replaceDirWithContents error: %v", err)
+	}
+	if !report.HadExistingTarget || !report.Committed || report.Recovered {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if report.BackupCleanupError != nil {
+		t.Fatalf("unexpected backup cleanup warning: %v", report.BackupCleanupError)
+	}
+	if got := readTestFile(t, filepath.Join(dst, "bin/tool.exe")); got != "new" {
+		t.Fatalf("target content = %q, want new", got)
+	}
+	if got := readTestFile(t, filepath.Join(stale, "recovery-marker")); got != "leave-me" {
+		t.Fatalf("pre-existing residue content = %q, want leave-me", got)
+	}
+	if _, err := os.Stat(report.StagingPath); !os.IsNotExist(err) {
+		t.Fatalf("staging path still exists after commit: %s (stat err %v)", report.StagingPath, err)
+	}
+	if _, err := os.Stat(report.BackupPath); !os.IsNotExist(err) {
+		t.Fatalf("backup path still exists after cleanup: %s (stat err %v)", report.BackupPath, err)
+	}
+}
+
+func TestReplaceDirWithContentsCopyFailureLeavesOldTargetUntouched(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "component")
+	writeTestFile(t, src, "new.txt", "new")
+	oldPath := writeTestFile(t, dst, "old.txt", "old")
+	copyErr := errors.New("injected copy failure")
+
+	ops := defaultReplaceDirFS()
+	ops.copyDirContents = func(string, string) error { return copyErr }
+	report, err := replaceDirWithContents(ops, src, dst)
+	if !errors.Is(err, copyErr) {
+		t.Fatalf("error = %v, want copy failure", err)
+	}
+	if report.Phase != ReplaceDirPhasePrepare {
+		t.Fatalf("phase = %q, want prepare", report.Phase)
+	}
+	if got := readTestFile(t, oldPath); got != "old" {
+		t.Fatalf("old target content = %q, want old", got)
+	}
+	if _, statErr := os.Stat(report.StagingPath); !os.IsNotExist(statErr) {
+		t.Fatalf("failed staging was not cleaned: %s (stat err %v)", report.StagingPath, statErr)
+	}
+}
+
+func TestReplaceDirWithContentsBackupRenameFailureDoesNotDeleteTarget(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "component")
+	writeTestFile(t, src, "new.txt", "new")
+	oldPath := writeTestFile(t, dst, "old.txt", "old")
+	renameErr := errors.New("injected backup rename failure")
+
+	ops := defaultReplaceDirFS()
+	var renameCalls int
+	ops.rename = func(old, new string) error {
+		renameCalls++
+		if renameCalls == 1 {
+			return renameErr
+		}
+		return os.Rename(old, new)
+	}
+	report, err := replaceDirWithContents(ops, src, dst)
+	if !errors.Is(err, renameErr) {
+		t.Fatalf("error = %v, want backup rename failure", err)
+	}
+	if report.Phase != ReplaceDirPhaseBackup {
+		t.Fatalf("phase = %q, want backup", report.Phase)
+	}
+	if got := readTestFile(t, oldPath); got != "old" {
+		t.Fatalf("old target content = %q, want old", got)
+	}
+	if _, statErr := os.Stat(report.StagingPath); !os.IsNotExist(statErr) {
+		t.Fatalf("failed staging was not cleaned: %s (stat err %v)", report.StagingPath, statErr)
+	}
+}
+
+func TestReplaceDirWithContentsCommitFailureRestoresOldAndRetainsStaging(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "component")
+	writeTestFile(t, src, "new.txt", "new")
+	oldPath := writeTestFile(t, dst, "old.txt", "old")
+	commitErr := errors.New("injected commit rename failure")
+
+	ops := defaultReplaceDirFS()
+	var renameCalls int
+	ops.rename = func(old, new string) error {
+		renameCalls++
+		if renameCalls == 2 {
+			return commitErr
+		}
+		return os.Rename(old, new)
+	}
+	report, err := replaceDirWithContents(ops, src, dst)
+	if !errors.Is(err, commitErr) {
+		t.Fatalf("error = %v, want commit failure", err)
+	}
+	if !report.Recovered || report.Phase != ReplaceDirPhaseCommit {
+		t.Fatalf("unexpected report after recovery: %+v", report)
+	}
+	if got := readTestFile(t, oldPath); got != "old" {
+		t.Fatalf("restored target content = %q, want old", got)
+	}
+	if _, statErr := os.Stat(report.StagingPath); statErr != nil {
+		t.Fatalf("staging should be retained after commit failure: %s (stat err %v)", report.StagingPath, statErr)
+	}
+	if _, statErr := os.Stat(report.BackupPath); !os.IsNotExist(statErr) {
+		t.Fatalf("restored backup path should be gone: %s (stat err %v)", report.BackupPath, statErr)
+	}
+	var replaceErr *ReplaceDirError
+	if !errors.As(err, &replaceErr) || !replaceErr.Recovered {
+		t.Fatalf("error does not report successful recovery: %T %v", err, err)
+	}
+}
+
+func TestReplaceDirWithContentsRecoveryFailureKeepsBothRecoveryPaths(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "component")
+	writeTestFile(t, src, "new.txt", "new")
+	writeTestFile(t, dst, "old.txt", "old")
+	commitErr := errors.New("injected commit rename failure")
+	restoreErr := errors.New("injected restore rename failure")
+
+	ops := defaultReplaceDirFS()
+	var renameCalls int
+	ops.rename = func(old, new string) error {
+		renameCalls++
+		switch renameCalls {
+		case 2:
+			return commitErr
+		case 3:
+			return restoreErr
+		default:
+			return os.Rename(old, new)
+		}
+	}
+	report, err := replaceDirWithContents(ops, src, dst)
+	if !errors.Is(err, commitErr) || !errors.Is(err, restoreErr) {
+		t.Fatalf("error = %v, want both commit and restore failures", err)
+	}
+	if report.Recovered || report.Phase != ReplaceDirPhaseRestore {
+		t.Fatalf("unexpected report after failed recovery: %+v", report)
+	}
+	if _, statErr := os.Stat(report.StagingPath); statErr != nil {
+		t.Fatalf("staging must be retained: %s (stat err %v)", report.StagingPath, statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(report.StagingPath, "new.txt")); statErr != nil {
+		t.Fatalf("staging content missing: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(report.BackupPath, "old.txt")); statErr != nil {
+		t.Fatalf("backup content missing: %v", statErr)
+	}
+	if _, statErr := os.Stat(dst); !os.IsNotExist(statErr) {
+		t.Fatalf("target should remain absent after failed recovery, stat err = %v", statErr)
+	}
+	if !strings.Contains(err.Error(), report.StagingPath) || !strings.Contains(err.Error(), report.BackupPath) {
+		t.Fatalf("error %q does not include recovery paths", err)
+	}
+}
+
+func TestReplaceDirWithContentsBackupCleanupFailureIsWarningAfterCommit(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "component")
+	writeTestFile(t, src, "new.txt", "new")
+	writeTestFile(t, dst, "old.txt", "old")
+	cleanupErr := errors.New("injected backup cleanup failure")
+
+	ops := defaultReplaceDirFS()
+	var removeCalls int
+	ops.removeAll = func(path string) error {
+		removeCalls++
+		if removeCalls == 2 {
+			return cleanupErr
+		}
+		return os.RemoveAll(path)
+	}
+	report, err := replaceDirWithContents(ops, src, dst)
+	if err != nil {
+		t.Fatalf("cleanup warning must not fail committed install: %v", err)
+	}
+	if !report.Committed || report.BackupCleanupError == nil {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if !errors.Is(report.BackupCleanupError, cleanupErr) {
+		t.Fatalf("backup cleanup error = %v, want injected error", report.BackupCleanupError)
+	}
+	if got := readTestFile(t, filepath.Join(dst, "new.txt")); got != "new" {
+		t.Fatalf("target content = %q, want new", got)
+	}
+	if got := readTestFile(t, filepath.Join(report.BackupPath, "old.txt")); got != "old" {
+		t.Fatalf("retained backup content = %q, want old", got)
+	}
+}
+
+func TestReplaceDirWithContentsFirstInstallCommitFailureRetainsStaging(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "component")
+	writeTestFile(t, src, "new.txt", "new")
+	commitErr := errors.New("injected first-install commit failure")
+
+	ops := defaultReplaceDirFS()
+	ops.rename = func(string, string) error { return commitErr }
+	report, err := replaceDirWithContents(ops, src, dst)
+	if !errors.Is(err, commitErr) {
+		t.Fatalf("error = %v, want commit failure", err)
+	}
+	if report.HadExistingTarget || report.BackupPath != "" {
+		t.Fatalf("first install unexpectedly has backup: %+v", report)
+	}
+	if _, statErr := os.Stat(dst); !os.IsNotExist(statErr) {
+		t.Fatalf("target should remain absent, stat err = %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(report.StagingPath, "new.txt")); statErr != nil {
+		t.Fatalf("staging content missing: %v", statErr)
+	}
+}
+
+func TestReplaceDirWithContentsParentFailureDoesNotTouchTarget(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "component")
+	writeTestFile(t, src, "new.txt", "new")
+	oldPath := writeTestFile(t, dst, "old.txt", "old")
+	parentErr := errors.New("injected target parent not writable")
+
+	ops := defaultReplaceDirFS()
+	ops.mkdirAll = func(string, os.FileMode) error { return parentErr }
+	report, err := replaceDirWithContents(ops, src, dst)
+	if !errors.Is(err, parentErr) {
+		t.Fatalf("error = %v, want parent failure", err)
+	}
+	if report.StagingPath != "" || report.BackupPath != "" {
+		t.Fatalf("no transaction paths should be created before parent setup: %+v", report)
+	}
+	if got := readTestFile(t, oldPath); got != "old" {
+		t.Fatalf("old target content = %q, want old", got)
+	}
+}
+
+func TestReplaceDirErrorUnwrapsPrimaryAndRecovery(t *testing.T) {
+	primary := errors.New("primary")
+	recovery := errors.New("recovery")
+	report := ReplaceDirReport{
+		TargetPath:  filepath.Join("tmp", "component"),
+		StagingPath: filepath.Join("tmp", "staging"),
+		BackupPath:  filepath.Join("tmp", "backup"),
+	}
+	err := replaceDirError(report, ReplaceDirPhaseRestore, primary, fmt.Errorf("wrapped: %w", recovery))
+	if !errors.Is(err, primary) || !errors.Is(err, recovery) {
+		t.Fatalf("error = %v, want both causes", err)
+	}
+	if !strings.Contains(err.Error(), report.StagingPath) || !strings.Contains(err.Error(), report.BackupPath) {
+		t.Fatalf("error %q does not include paths", err)
+	}
+}

--- a/internal/download/archive_test.go
+++ b/internal/download/archive_test.go
@@ -1,12 +1,17 @@
 package download
 
 import (
+	"archive/zip"
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func writeTestFile(t *testing.T, root, name, contents string) string {
@@ -300,5 +305,97 @@ func TestReplaceDirErrorUnwrapsPrimaryAndRecovery(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), report.StagingPath) || !strings.Contains(err.Error(), report.BackupPath) {
 		t.Fatalf("error %q does not include paths", err)
+	}
+}
+
+// writeTestZip writes a small archive used by the extraction tests.
+func writeTestZip(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create zip %s: %v", path, err)
+	}
+	writer := zip.NewWriter(file)
+	for name, contents := range entries {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry %s: %v", name, err)
+		}
+		if _, err := entry.Write([]byte(contents)); err != nil {
+			t.Fatalf("write zip entry %s: %v", name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close zip writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close zip file: %v", err)
+	}
+}
+
+func TestUnzipWithContextRejectsCanceledContextBeforeExtraction(t *testing.T) {
+	root := t.TempDir()
+	archivePath := filepath.Join(root, "demo.zip")
+	writeTestZip(t, archivePath, map[string]string{"inner.dem": "payload"})
+	destDir := filepath.Join(root, "extract")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := UnzipWithContext(ctx, archivePath, destDir)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("UnzipWithContext error = %v, want context.Canceled", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(destDir, "inner.dem")); !os.IsNotExist(statErr) {
+		t.Fatalf("canceled extraction created an entry, stat err=%v", statErr)
+	}
+}
+
+// endlessReader never returns io.EOF. The only way the extraction can finish
+// is its own context check between copy chunks, which makes the cancellation
+// assertion independent of file size or timing.
+type endlessReader struct {
+	started chan struct{}
+	once    *sync.Once
+}
+
+func (r *endlessReader) Read(p []byte) (int, error) {
+	r.once.Do(func() { close(r.started) })
+	for i := range p {
+		p[i] = 'x'
+	}
+	return len(p), nil
+}
+
+func TestUnzipWithContextStopsEntryCopyWhenCanceled(t *testing.T) {
+	root := t.TempDir()
+	archivePath := filepath.Join(root, "demo.zip")
+	writeTestZip(t, archivePath, map[string]string{"inner.dem": "payload"})
+	destDir := filepath.Join(root, "extract")
+
+	started := make(chan struct{})
+	var startOnce sync.Once
+	ops := defaultUnzipOps()
+	ops.openEntry = func(*zip.File) (io.ReadCloser, error) {
+		return io.NopCloser(&endlessReader{started: started, once: &startOnce}), nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- unzipWithContext(ctx, archivePath, destDir, ops) }()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("entry copy never started")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("UnzipWithContext error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("extraction did not observe cancellation during the entry copy")
 	}
 }

--- a/internal/download/file_commit.go
+++ b/internal/download/file_commit.go
@@ -1,0 +1,332 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// CopyFile copies src to dst using a same-directory temporary file and a
+// commit rename.  A failed read, close, or rename never exposes a partial
+// destination.  Existing destinations are moved aside while the commit is
+// attempted so that a failed replacement can restore the previous file (this
+// also works on Windows, where Rename does not replace an existing path).
+func CopyFile(src, dst string) error {
+	return CopyFileAtomicWithContext(context.Background(), src, dst)
+}
+
+// CopyFileAtomic is the explicit name for the transactional CopyFile
+// contract.  CopyFile remains the compatibility entry point used by existing
+// callers.
+func CopyFileAtomic(src, dst string) error {
+	return CopyFileAtomicWithContext(context.Background(), src, dst)
+}
+
+// CopyFileAtomicWithContext is CopyFileAtomic with cancellation checks before
+// and during the copy and immediately before the commit rename.
+func CopyFileAtomicWithContext(ctx context.Context, src, dst string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	source := filepath.Clean(strings.TrimSpace(src))
+	target := filepath.Clean(strings.TrimSpace(dst))
+	if source == "." || strings.TrimSpace(src) == "" {
+		return fmt.Errorf("源文件路径为空")
+	}
+	if target == "." || strings.TrimSpace(dst) == "" {
+		return fmt.Errorf("目标文件路径为空")
+	}
+	if sameFilePath(source, target) {
+		return nil
+	}
+	if err := contextErr(ctx); err != nil {
+		return err
+	}
+
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("源路径不是普通文件: %s", source)
+	}
+
+	return copyReaderAtomicWithOps(ctx, in, target, info.Mode().Perm(), defaultAtomicCopyOps())
+}
+
+// CopyReaderAtomic commits bytes supplied by reader to dst atomically.  It is
+// intentionally small so callers that already own a reader do not need to
+// materialize it before committing.  The reader is not closed by this helper.
+func CopyReaderAtomic(ctx context.Context, reader io.Reader, dst string) error {
+	return copyReaderAtomicWithOps(ctx, reader, dst, 0644, defaultAtomicCopyOps())
+}
+
+// IsLikelyDemoFile performs the deliberately limited validation used for old
+// demo cache entries.  It rejects missing/non-regular/too-short files and
+// checks only the eight-byte file stamp.  A positive result is not proof that
+// the demo is complete; tail truncation still requires the normal parser to
+// detect it.
+func IsLikelyDemoFile(path string) (bool, error) {
+	filePath := filepath.Clean(strings.TrimSpace(path))
+	if filePath == "." || strings.TrimSpace(path) == "" {
+		return false, nil
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	const fileStampSize = 8
+	if !info.Mode().IsRegular() || info.Size() < fileStampSize {
+		return false, nil
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	stamp := make([]byte, fileStampSize)
+	if _, err := io.ReadFull(f, stamp); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return false, nil
+		}
+		return false, err
+	}
+	// PBDEMS2 is the CS2 demo stamp. HL2DEMO is accepted as a basic legacy
+	// shape check; the parser remains responsible for deciding whether that
+	// older format is usable by the application. Demo stamps are C strings, so
+	// the eighth byte is normally a NUL terminator.
+	stampText := strings.TrimRight(string(stamp), "\x00")
+	return stampText == "PBDEMS2" || stampText == "HL2DEMO", nil
+}
+
+type atomicCopyTemp interface {
+	io.Writer
+	Close() error
+}
+
+type atomicCopyOps struct {
+	stat       func(string) (os.FileInfo, error)
+	mkdirAll   func(string, os.FileMode) error
+	createTemp func(string, string) (string, atomicCopyTemp, error)
+	rename     func(string, string) error
+	remove     func(string) error
+	chmod      func(string, os.FileMode) error
+}
+
+func defaultAtomicCopyOps() atomicCopyOps {
+	return atomicCopyOps{
+		stat:       os.Stat,
+		mkdirAll:   os.MkdirAll,
+		createTemp: createAtomicCopyTemp,
+		rename:     os.Rename,
+		remove:     os.Remove,
+		chmod:      os.Chmod,
+	}
+}
+
+func (ops atomicCopyOps) withDefaults() atomicCopyOps {
+	defaults := defaultAtomicCopyOps()
+	if ops.stat == nil {
+		ops.stat = defaults.stat
+	}
+	if ops.mkdirAll == nil {
+		ops.mkdirAll = defaults.mkdirAll
+	}
+	if ops.createTemp == nil {
+		ops.createTemp = defaults.createTemp
+	}
+	if ops.rename == nil {
+		ops.rename = defaults.rename
+	}
+	if ops.remove == nil {
+		ops.remove = defaults.remove
+	}
+	if ops.chmod == nil {
+		ops.chmod = defaults.chmod
+	}
+	return ops
+}
+
+func createAtomicCopyTemp(dir, pattern string) (string, atomicCopyTemp, error) {
+	f, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", nil, err
+	}
+	return f.Name(), f, nil
+}
+
+func copyReaderAtomicWithOps(ctx context.Context, reader io.Reader, dst string, mode os.FileMode, ops atomicCopyOps) error {
+	ops = ops.withDefaults()
+	if reader == nil {
+		return fmt.Errorf("源读取器为空")
+	}
+	if err := contextErr(ctx); err != nil {
+		return err
+	}
+
+	target := filepath.Clean(strings.TrimSpace(dst))
+	if target == "." || strings.TrimSpace(dst) == "" {
+		return fmt.Errorf("目标文件路径为空")
+	}
+	parent := filepath.Dir(target)
+	if err := ops.mkdirAll(parent, 0755); err != nil {
+		return fmt.Errorf("创建目标目录失败: %w", err)
+	}
+
+	tmpPath, tmp, err := ops.createTemp(parent, "."+filepath.Base(target)+".copy-*.tmp")
+	if err != nil {
+		return fmt.Errorf("创建临时文件失败: %w", err)
+	}
+	removeTemp := func() error {
+		if removeErr := ops.remove(tmpPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			return fmt.Errorf("清理临时文件 %q 失败: %w", tmpPath, removeErr)
+		}
+		return nil
+	}
+
+	_, copyErr := io.Copy(tmp, contextReader{ctx: ctx, reader: reader})
+	closeErr := tmp.Close()
+	if copyErr != nil || closeErr != nil {
+		cleanupErr := removeTemp()
+		return errors.Join(
+			wrapCopyError("复制到临时文件失败", copyErr),
+			wrapCopyError("关闭临时文件失败", closeErr),
+			cleanupErr,
+		)
+	}
+	if err := contextErr(ctx); err != nil {
+		return errors.Join(err, removeTemp())
+	}
+	if mode == 0 {
+		mode = 0644
+	}
+	if err := ops.chmod(tmpPath, mode); err != nil {
+		return errors.Join(fmt.Errorf("设置临时文件权限失败: %w", err), removeTemp())
+	}
+
+	// Re-check at commit time so a destination created while the copy was in
+	// progress is protected by the same restore path as an existing cache.
+	_, statErr := ops.stat(target)
+	targetExists := statErr == nil
+	if statErr != nil && !os.IsNotExist(statErr) {
+		return errors.Join(fmt.Errorf("检查目标文件失败: %w", statErr), removeTemp())
+	}
+
+	var backupPath string
+	backupMoved := false
+	if targetExists {
+		backupPath, err = moveTargetToBackup(ops, parent, target)
+		if err != nil {
+			return errors.Join(err, removeTemp())
+		}
+		backupMoved = true
+	}
+
+	if err := contextErr(ctx); err != nil {
+		return restoreAfterCommitFailure(ops, target, backupPath, backupMoved, err, removeTemp)
+	}
+	if err := ops.rename(tmpPath, target); err != nil {
+		return restoreAfterCommitFailure(ops, target, backupPath, backupMoved,
+			fmt.Errorf("提交目标文件失败: %w", err), removeTemp)
+	}
+
+	// The new target is committed.  A stale backup is never allowed to turn a
+	// successful cache import into a failure; leave it for a later cleanup if a
+	// filesystem refuses removal.
+	if backupMoved {
+		_ = ops.remove(backupPath)
+	}
+	return nil
+}
+
+func moveTargetToBackup(ops atomicCopyOps, parent, target string) (string, error) {
+	backupPath, backup, err := ops.createTemp(parent, "."+filepath.Base(target)+".backup-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("创建缓存备份临时文件失败: %w", err)
+	}
+	if err := backup.Close(); err != nil {
+		_ = ops.remove(backupPath)
+		return "", fmt.Errorf("关闭缓存备份临时文件失败: %w", err)
+	}
+	if err := ops.remove(backupPath); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("准备缓存备份路径失败: %w", err)
+	}
+	if err := ops.rename(target, backupPath); err != nil {
+		return "", fmt.Errorf("备份旧缓存失败: %w", err)
+	}
+	return backupPath, nil
+}
+
+func restoreAfterCommitFailure(
+	ops atomicCopyOps,
+	target, backupPath string,
+	backupMoved bool,
+	primary error,
+	removeTemp func() error,
+) error {
+	cleanupErr := removeTemp()
+	if !backupMoved {
+		return errors.Join(primary, cleanupErr)
+	}
+	restoreErr := ops.rename(backupPath, target)
+	if restoreErr != nil {
+		return errors.Join(primary, fmt.Errorf("恢复旧缓存失败: %w", restoreErr), cleanupErr)
+	}
+	return errors.Join(primary, cleanupErr)
+}
+
+func wrapCopyError(message string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", message, err)
+}
+
+func contextErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+type contextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r contextReader) Read(p []byte) (int, error) {
+	if err := contextErr(r.ctx); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(p)
+}
+
+func sameFilePath(a, b string) bool {
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}

--- a/internal/download/file_commit.go
+++ b/internal/download/file_commit.go
@@ -224,10 +224,19 @@ func copyReaderAtomicWithOps(ctx context.Context, reader io.Reader, dst string, 
 
 	// Re-check at commit time so a destination created while the copy was in
 	// progress is protected by the same restore path as an existing cache.
-	_, statErr := ops.stat(target)
+	// The type is checked as well: moving an existing directory to the backup
+	// path and committing a regular file over it would silently destroy the
+	// directory (the previous stream-copy implementation refused to open it).
+	targetInfo, statErr := ops.stat(target)
 	targetExists := statErr == nil
 	if statErr != nil && !os.IsNotExist(statErr) {
 		return errors.Join(fmt.Errorf("检查目标文件失败: %w", statErr), removeTemp())
+	}
+	if targetExists && targetInfo != nil && !targetInfo.Mode().IsRegular() {
+		if targetInfo.IsDir() {
+			return errors.Join(fmt.Errorf("目标路径是目录，拒绝用文件覆盖: %s", target), removeTemp())
+		}
+		return errors.Join(fmt.Errorf("目标路径不是普通文件，拒绝覆盖: %s", target), removeTemp())
 	}
 
 	var backupPath string

--- a/internal/download/file_test.go
+++ b/internal/download/file_test.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -113,5 +114,172 @@ func TestFileWithContextRejectsIdleResponse(t *testing.T) {
 	}
 	if _, statErr := os.Stat(targetPath); !os.IsNotExist(statErr) {
 		t.Fatalf("stalled target exists after failure, stat err = %v", statErr)
+	}
+}
+
+func TestCopyReaderAtomicReadFailurePreservesExistingTarget(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "match.dem")
+	if err := os.WriteFile(targetPath, []byte("previous-demo"), 0644); err != nil {
+		t.Fatalf("write existing target: %v", err)
+	}
+
+	reader := &failAfterBytesReader{data: []byte("partial-demo"), err: errors.New("injected source read failure")}
+	err := CopyReaderAtomic(context.Background(), reader, targetPath)
+	if err == nil || !errors.Is(err, reader.err) {
+		t.Fatalf("CopyReaderAtomic error = %v, want source read failure", err)
+	}
+	assertFileContent(t, targetPath, "previous-demo")
+	assertNoAtomicCopyTemps(t, root, "match.dem")
+}
+
+func TestCopyReaderAtomicReadFailureLeavesNewTargetAbsent(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "match.dem")
+	reader := &failAfterBytesReader{data: []byte("partial-demo"), err: errors.New("injected source read failure")}
+
+	err := CopyReaderAtomic(context.Background(), reader, targetPath)
+	if err == nil || !errors.Is(err, reader.err) {
+		t.Fatalf("CopyReaderAtomic error = %v, want source read failure", err)
+	}
+	if _, statErr := os.Stat(targetPath); !os.IsNotExist(statErr) {
+		t.Fatalf("failed new target exists, stat err=%v", statErr)
+	}
+	assertNoAtomicCopyTemps(t, root, "match.dem")
+}
+
+func TestCopyReaderAtomicCloseFailurePreservesExistingTarget(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "match.dem")
+	if err := os.WriteFile(targetPath, []byte("previous-demo"), 0644); err != nil {
+		t.Fatalf("write existing target: %v", err)
+	}
+	closeErr := errors.New("injected temp close failure")
+	ops := defaultAtomicCopyOps()
+	ops.createTemp = func(dir, pattern string) (string, atomicCopyTemp, error) {
+		file, err := os.CreateTemp(dir, pattern)
+		if err != nil {
+			return "", nil, err
+		}
+		return file.Name(), &closeErrorTemp{File: file, err: closeErr}, nil
+	}
+
+	err := copyReaderAtomicWithOps(context.Background(), bytes.NewReader([]byte("complete-demo")), targetPath, 0644, ops)
+	if err == nil || !errors.Is(err, closeErr) {
+		t.Fatalf("copyReaderAtomicWithOps error = %v, want close failure", err)
+	}
+	assertFileContent(t, targetPath, "previous-demo")
+	assertNoAtomicCopyTemps(t, root, "match.dem")
+}
+
+func TestCopyReaderAtomicCommitFailureRestoresExistingTarget(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "match.dem")
+	if err := os.WriteFile(targetPath, []byte("previous-demo"), 0644); err != nil {
+		t.Fatalf("write existing target: %v", err)
+	}
+	commitErr := errors.New("injected commit rename failure")
+	ops := defaultAtomicCopyOps()
+	renameCalls := 0
+	ops.rename = func(old, new string) error {
+		renameCalls++
+		if renameCalls == 2 {
+			return commitErr
+		}
+		return os.Rename(old, new)
+	}
+
+	err := copyReaderAtomicWithOps(context.Background(), bytes.NewReader([]byte("new-demo")), targetPath, 0644, ops)
+	if err == nil || !errors.Is(err, commitErr) {
+		t.Fatalf("copyReaderAtomicWithOps error = %v, want commit failure", err)
+	}
+	assertFileContent(t, targetPath, "previous-demo")
+	assertNoAtomicCopyTemps(t, root, "match.dem")
+}
+
+func TestCopyReaderAtomicCommitFailureLeavesNewTargetAbsent(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "match.dem")
+	commitErr := errors.New("injected commit rename failure")
+	ops := defaultAtomicCopyOps()
+	ops.rename = func(old, new string) error { return commitErr }
+
+	err := copyReaderAtomicWithOps(context.Background(), bytes.NewReader([]byte("new-demo")), targetPath, 0644, ops)
+	if err == nil || !errors.Is(err, commitErr) {
+		t.Fatalf("copyReaderAtomicWithOps error = %v, want commit failure", err)
+	}
+	if _, statErr := os.Stat(targetPath); !os.IsNotExist(statErr) {
+		t.Fatalf("failed new target exists, stat err=%v", statErr)
+	}
+	assertNoAtomicCopyTemps(t, root, "match.dem")
+}
+
+func TestIsLikelyDemoFileRejectsObviousCorruption(t *testing.T) {
+	root := t.TempDir()
+	validPath := filepath.Join(root, "valid.dem")
+	if err := os.WriteFile(validPath, []byte("PBDEMS2\x00truncated-tail-is-unknown"), 0644); err != nil {
+		t.Fatalf("write valid-shaped demo: %v", err)
+	}
+	valid, err := IsLikelyDemoFile(validPath)
+	if err != nil || !valid {
+		t.Fatalf("IsLikelyDemoFile(valid) = %v, %v; want true", valid, err)
+	}
+
+	invalidPath := filepath.Join(root, "invalid.dem")
+	if err := os.WriteFile(invalidPath, []byte("partial"), 0644); err != nil {
+		t.Fatalf("write invalid demo: %v", err)
+	}
+	valid, err = IsLikelyDemoFile(invalidPath)
+	if err != nil || valid {
+		t.Fatalf("IsLikelyDemoFile(invalid) = %v, %v; want false", valid, err)
+	}
+}
+
+type failAfterBytesReader struct {
+	data []byte
+	err  error
+}
+
+func (r *failAfterBytesReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, r.err
+	}
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	return n, nil
+}
+
+type closeErrorTemp struct {
+	*os.File
+	err error
+}
+
+func (f *closeErrorTemp) Close() error {
+	closeErr := f.File.Close()
+	if closeErr != nil {
+		return closeErr
+	}
+	return f.err
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(data) != want {
+		t.Fatalf("file %s = %q, want %q", path, string(data), want)
+	}
+}
+
+func assertNoAtomicCopyTemps(t *testing.T, dir, base string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "."+base+".copy-*.tmp"))
+	if err != nil {
+		t.Fatalf("glob atomic copy temps: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("atomic copy temp files remain: %v", matches)
 	}
 }

--- a/internal/download/file_test.go
+++ b/internal/download/file_test.go
@@ -214,6 +214,58 @@ func TestCopyReaderAtomicCommitFailureLeavesNewTargetAbsent(t *testing.T) {
 	assertNoAtomicCopyTemps(t, root, "match.dem")
 }
 
+func TestCopyFileRejectsExistingEmptyDirectoryTarget(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "source.dem")
+	if err := os.WriteFile(sourcePath, []byte("new-demo"), 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	targetPath := filepath.Join(root, "match.dem")
+	if err := os.Mkdir(targetPath, 0755); err != nil {
+		t.Fatalf("create directory target: %v", err)
+	}
+
+	err := CopyFile(sourcePath, targetPath)
+	if err == nil {
+		t.Fatal("CopyFile succeeded, want directory target rejection")
+	}
+	if !strings.Contains(err.Error(), "目录") {
+		t.Fatalf("CopyFile error = %v, want directory rejection", err)
+	}
+	info, statErr := os.Stat(targetPath)
+	if statErr != nil {
+		t.Fatalf("empty directory target was moved or removed: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target mode = %v, want directory", info.Mode())
+	}
+	assertNoAtomicCopyTemps(t, root, "match.dem")
+	assertNoAtomicCopyBackups(t, root, "match.dem")
+}
+
+func TestCopyReaderAtomicRejectsNonEmptyDirectoryTarget(t *testing.T) {
+	root := t.TempDir()
+	targetPath := filepath.Join(root, "match.dem")
+	if err := os.MkdirAll(filepath.Join(targetPath, "nested"), 0755); err != nil {
+		t.Fatalf("create directory target: %v", err)
+	}
+	markerPath := filepath.Join(targetPath, "nested", "keep.txt")
+	if err := os.WriteFile(markerPath, []byte("keep-me"), 0644); err != nil {
+		t.Fatalf("write directory marker: %v", err)
+	}
+
+	err := CopyReaderAtomic(context.Background(), bytes.NewReader([]byte("new-demo")), targetPath)
+	if err == nil {
+		t.Fatal("CopyReaderAtomic succeeded, want directory target rejection")
+	}
+	if _, statErr := os.Stat(targetPath); statErr != nil {
+		t.Fatalf("non-empty directory target was moved or removed: %v", statErr)
+	}
+	assertFileContent(t, markerPath, "keep-me")
+	assertNoAtomicCopyTemps(t, root, "match.dem")
+	assertNoAtomicCopyBackups(t, root, "match.dem")
+}
+
 func TestIsLikelyDemoFileRejectsObviousCorruption(t *testing.T) {
 	root := t.TempDir()
 	validPath := filepath.Join(root, "valid.dem")
@@ -281,5 +333,16 @@ func assertNoAtomicCopyTemps(t *testing.T, dir, base string) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("atomic copy temp files remain: %v", matches)
+	}
+}
+
+func assertNoAtomicCopyBackups(t *testing.T, dir, base string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "."+base+".backup-*.tmp"))
+	if err != nil {
+		t.Fatalf("glob atomic copy backups: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("atomic copy backups remain: %v", matches)
 	}
 }

--- a/internal/envsetup/ffmpeg.go
+++ b/internal/envsetup/ffmpeg.go
@@ -108,8 +108,16 @@ func (s *Service) installFFmpegFromArchive(path string) error {
 		s.logStepFail(componentFFmpeg, "validate", "verify_archive", string(s.currentSource()), 0, validateStarted, err, nil)
 		return err
 	}
-	binDir := filepath.Dir(ffmpegExe)
-	root := filepath.Dir(binDir)
+	// Validate the exact installed layout before the transactional replacement
+	// moves the existing <dataDir>/ffmpeg aside.  An archive that nests
+	// ffmpeg.exe somewhere else (for example release/tools/ffmpeg.exe) would
+	// otherwise destroy the old working installation and only fail the
+	// post-commit existence check afterwards.
+	root, err := ffmpegArchiveRoot(ffmpegExe)
+	if err != nil {
+		s.logStepFail(componentFFmpeg, "validate", "verify_archive", string(s.currentSource()), 0, validateStarted, err, nil)
+		return err
+	}
 	targetRoot := filepath.Join(s.dataDir, "ffmpeg")
 	replaceReport, err := download.ReplaceDirWithContentsWithReport(root, targetRoot)
 	if err != nil {
@@ -165,6 +173,24 @@ func (s *Service) installFFmpegFromArchive(path string) error {
 	s.tryWriteHLAEFfmpegIni(filepath.Join(cfg.FFmpegDir, "ffmpeg.exe"))
 	s.scheduleFFmpegCapabilityDetection(filepath.Join(cfg.FFmpegDir, "ffmpeg.exe"))
 	return nil
+}
+
+// ffmpegArchiveRoot resolves the directory whose contents are committed into
+// <dataDir>/ffmpeg and verifies the layout the rest of the application relies
+// on: ffmpeg.exe must be directly inside a bin/ directory so that, after the
+// directory replacement, it exists at <dataDir>/ffmpeg/bin/ffmpeg.exe (the
+// path stored in config.FFmpegDir and written to HLAE's ffmpeg.ini).
+func ffmpegArchiveRoot(ffmpegExe string) (string, error) {
+	binDir := filepath.Dir(ffmpegExe)
+	root := filepath.Dir(binDir)
+	relative, err := filepath.Rel(root, ffmpegExe)
+	if err != nil {
+		return "", fmt.Errorf("计算 ffmpeg 归档相对路径失败: %w", err)
+	}
+	if !strings.EqualFold(filepath.ToSlash(relative), "bin/ffmpeg.exe") {
+		return "", fmt.Errorf("ffmpeg 压缩包布局不符合预期: 需要 bin/ffmpeg.exe，实际为 %s", filepath.ToSlash(relative))
+	}
+	return root, nil
 }
 
 func (s *Service) scheduleFFmpegCapabilityDetection(ffmpegExe string) {

--- a/internal/envsetup/ffmpeg.go
+++ b/internal/envsetup/ffmpeg.go
@@ -111,9 +111,21 @@ func (s *Service) installFFmpegFromArchive(path string) error {
 	binDir := filepath.Dir(ffmpegExe)
 	root := filepath.Dir(binDir)
 	targetRoot := filepath.Join(s.dataDir, "ffmpeg")
-	if err := download.ReplaceDirWithContents(root, targetRoot); err != nil {
+	replaceReport, err := download.ReplaceDirWithContentsWithReport(root, targetRoot)
+	if err != nil {
 		s.logStepFail(componentFFmpeg, "validate", "verify_archive", string(s.currentSource()), 0, validateStarted, err, nil)
 		return err
+	}
+	if replaceReport.BackupCleanupError != nil {
+		s.emitLogWithFields("warning", "ffmpeg 旧版本备份清理失败，已保留供恢复", logFields{
+			Component: componentFFmpeg,
+			Stage:     "commit",
+			Action:    "cleanup_backup",
+			Error:     replaceReport.BackupCleanupError.Error(),
+			Meta: map[string]string{
+				"backup_path": replaceReport.BackupPath,
+			},
+		})
 	}
 	ffmpegDir := filepath.Join(targetRoot, "bin")
 	if _, err := os.Stat(filepath.Join(ffmpegDir, "ffmpeg.exe")); err != nil {

--- a/internal/envsetup/ffmpeg_install_safety_test.go
+++ b/internal/envsetup/ffmpeg_install_safety_test.go
@@ -1,0 +1,123 @@
+package envsetup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInstallFFmpegFromArchiveValidatesLayoutBeforeReplacingExistingInstall
+// covers the regression where an archive whose ffmpeg.exe is not directly
+// inside a bin/ directory passed the extraction check, replaced the working
+// installation, and only then failed the post-commit existence check.
+func TestInstallFFmpegFromArchiveValidatesLayoutBeforeReplacingExistingInstall(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries map[string][]byte
+	}{
+		{
+			name: "ffmpeg exe nested outside bin",
+			entries: map[string][]byte{
+				"release/tools/ffmpeg.exe": []byte("new-ffmpeg"),
+			},
+		},
+		{
+			name: "ffmpeg exe flat at archive root",
+			entries: map[string][]byte{
+				"ffmpeg.exe": []byte("new-ffmpeg"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			svc := NewWithDataDir(t.TempDir(), dataDir, "test")
+			svc.Startup(nil)
+
+			targetDir := filepath.Join(dataDir, "ffmpeg")
+			oldExe := filepath.Join(targetDir, "bin", "ffmpeg.exe")
+			if err := os.MkdirAll(filepath.Dir(oldExe), 0755); err != nil {
+				t.Fatalf("create old ffmpeg directory: %v", err)
+			}
+			if err := os.WriteFile(oldExe, []byte("known-good-old-ffmpeg"), 0644); err != nil {
+				t.Fatalf("write old ffmpeg.exe: %v", err)
+			}
+			markerPath := filepath.Join(targetDir, "preserve.txt")
+			if err := os.WriteFile(markerPath, []byte("known-good-old-install"), 0644); err != nil {
+				t.Fatalf("write old ffmpeg marker: %v", err)
+			}
+
+			archivePath := createZipForTest(t, tt.entries)
+			err := svc.installFFmpegFromArchive(archivePath)
+			if err == nil {
+				t.Fatal("installFFmpegFromArchive succeeded for an unexpected layout")
+			}
+			if !strings.Contains(err.Error(), "bin/ffmpeg.exe") {
+				t.Fatalf("error = %q, want substring %q", err, "bin/ffmpeg.exe")
+			}
+			data, readErr := os.ReadFile(oldExe)
+			if readErr != nil {
+				t.Fatalf("old ffmpeg.exe was removed: %v", readErr)
+			}
+			if string(data) != "known-good-old-ffmpeg" {
+				t.Fatalf("old ffmpeg.exe = %q, want known-good-old-ffmpeg", data)
+			}
+			marker, markerErr := os.ReadFile(markerPath)
+			if markerErr != nil {
+				t.Fatalf("old ffmpeg install was replaced: %v", markerErr)
+			}
+			if string(marker) != "known-good-old-install" {
+				t.Fatalf("old ffmpeg marker = %q, want known-good-old-install", marker)
+			}
+			assertNoReplaceDirResidue(t, dataDir, "ffmpeg")
+		})
+	}
+}
+
+func TestInstallFFmpegFromArchiveAcceptsBinLayoutAndReplacesOldVersion(t *testing.T) {
+	dataDir := t.TempDir()
+	svc := NewWithDataDir(t.TempDir(), dataDir, "test")
+	svc.Startup(nil)
+
+	targetDir := filepath.Join(dataDir, "ffmpeg")
+	oldExe := filepath.Join(targetDir, "bin", "ffmpeg.exe")
+	if err := os.MkdirAll(filepath.Dir(oldExe), 0755); err != nil {
+		t.Fatalf("create old ffmpeg directory: %v", err)
+	}
+	if err := os.WriteFile(oldExe, []byte("old-ffmpeg"), 0644); err != nil {
+		t.Fatalf("write old ffmpeg.exe: %v", err)
+	}
+
+	archivePath := createZipForTest(t, map[string][]byte{
+		"package/bin/ffmpeg.exe": []byte("new-ffmpeg"),
+		"package/readme.txt":     []byte("doc"),
+	})
+	if err := svc.installFFmpegFromArchive(archivePath); err != nil {
+		t.Fatalf("installFFmpegFromArchive error: %v", err)
+	}
+
+	installedExe := filepath.Join(dataDir, "ffmpeg", "bin", "ffmpeg.exe")
+	data, err := os.ReadFile(installedExe)
+	if err != nil {
+		t.Fatalf("read installed ffmpeg.exe: %v", err)
+	}
+	if string(data) != "new-ffmpeg" {
+		t.Fatalf("installed ffmpeg.exe = %q, want new-ffmpeg", data)
+	}
+	assertNoReplaceDirResidue(t, dataDir, "ffmpeg")
+}
+
+func assertNoReplaceDirResidue(t *testing.T, parent, base string) {
+	t.Helper()
+	for _, pattern := range []string{"." + base + ".staging-*", "." + base + ".backup-*"} {
+		matches, err := filepath.Glob(filepath.Join(parent, pattern))
+		if err != nil {
+			t.Fatalf("glob %s: %v", pattern, err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("directory replacement residue remains for %s: %v", pattern, matches)
+		}
+	}
+}

--- a/internal/envsetup/hlae.go
+++ b/internal/envsetup/hlae.go
@@ -123,11 +123,35 @@ func (s *Service) installHLAEFromArchive(archivePath string) error {
 		s.logStepFail(componentHLAE, "validate", "verify_archive", string(s.currentSource()), 0, validateStarted, err, nil)
 		return err
 	}
-	root := filepath.Dir(hlaeExe)
-	targetDir := filepath.Join(s.dataDir, "hlae")
-	if err := download.ReplaceDirWithContents(root, targetDir); err != nil {
+	// Validate the extracted component before moving the existing installation
+	// out of the way.  ReplaceDirWithContentsWithReport deliberately protects
+	// filesystem commit boundaries, while component-specific requirements stay
+	// here in envsetup.
+	if err := validateHLAE(hlaeExe); err != nil {
 		s.logStepFail(componentHLAE, "validate", "verify_archive", string(s.currentSource()), 0, validateStarted, err, nil)
 		return err
+	}
+	if _, err := resolveInstalledHLAEVersion(hlaeExe); err != nil {
+		s.logStepFail(componentHLAE, "validate", "verify_archive", string(s.currentSource()), 0, validateStarted, err, nil)
+		return err
+	}
+	root := filepath.Dir(hlaeExe)
+	targetDir := filepath.Join(s.dataDir, "hlae")
+	replaceReport, err := download.ReplaceDirWithContentsWithReport(root, targetDir)
+	if err != nil {
+		s.logStepFail(componentHLAE, "validate", "verify_archive", string(s.currentSource()), 0, validateStarted, err, nil)
+		return err
+	}
+	if replaceReport.BackupCleanupError != nil {
+		s.emitLogWithFields("warning", "HLAE 旧版本备份清理失败，已保留供恢复", logFields{
+			Component: componentHLAE,
+			Stage:     "commit",
+			Action:    "cleanup_backup",
+			Error:     replaceReport.BackupCleanupError.Error(),
+			Meta: map[string]string{
+				"backup_path": replaceReport.BackupPath,
+			},
+		})
 	}
 	targetExe := filepath.Join(targetDir, "HLAE.exe")
 	if err := validateHLAE(targetExe); err != nil {

--- a/internal/envsetup/hlae_install_safety_test.go
+++ b/internal/envsetup/hlae_install_safety_test.go
@@ -1,0 +1,71 @@
+package envsetup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallHLAEFromArchiveValidatesBeforeReplacingExistingInstall(t *testing.T) {
+	tests := []struct {
+		name     string
+		entries  map[string][]byte
+		wantPart string
+	}{
+		{
+			name: "missing hook dll",
+			entries: map[string][]byte{
+				"release/hlae.exe":      []byte("new-hlae"),
+				"release/changelog.xml": []byte("<changelog><version>2.0.0</version></changelog>"),
+			},
+			wantPart: "AfxHookSource2.dll",
+		},
+		{
+			name: "missing version",
+			entries: map[string][]byte{
+				"release/hlae.exe":               []byte("new-hlae"),
+				"release/x64/AfxHookSource2.dll": []byte("new-hook"),
+				"release/changelog.xml":          []byte("<changelog></changelog>"),
+			},
+			wantPart: "changelog.xml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exeDir := t.TempDir()
+			dataDir := t.TempDir()
+			svc := NewWithDataDir(exeDir, dataDir, "test")
+			svc.Startup(nil)
+
+			targetDir := filepath.Join(dataDir, "hlae")
+			markerPath := filepath.Join(targetDir, "preserve.txt")
+			if err := os.MkdirAll(targetDir, 0755); err != nil {
+				t.Fatalf("create old HLAE directory: %v", err)
+			}
+			if err := os.WriteFile(markerPath, []byte("known-good-old-install"), 0644); err != nil {
+				t.Fatalf("write old HLAE marker: %v", err)
+			}
+
+			archivePath := createZipForTest(t, tt.entries)
+			err := svc.installHLAEFromArchive(archivePath)
+			if err == nil {
+				t.Fatal("installHLAEFromArchive succeeded for an invalid archive")
+			}
+			if !strings.Contains(err.Error(), tt.wantPart) {
+				t.Fatalf("error = %q, want substring %q", err, tt.wantPart)
+			}
+			data, readErr := os.ReadFile(markerPath)
+			if readErr != nil {
+				t.Fatalf("old HLAE marker was removed: %v", readErr)
+			}
+			if string(data) != "known-good-old-install" {
+				t.Fatalf("old HLAE marker = %q, want known-good-old-install", data)
+			}
+			if _, statErr := os.Stat(filepath.Join(targetDir, "HLAE.exe")); !os.IsNotExist(statErr) {
+				t.Fatalf("invalid archive touched target HLAE.exe, stat err = %v", statErr)
+			}
+		})
+	}
+}

--- a/internal/fivee/client.go
+++ b/internal/fivee/client.go
@@ -3,6 +3,7 @@ package fivee
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -77,14 +78,25 @@ const (
 )
 
 var (
-	HTTPRequestFn    = defaultHTTPRequest
-	DownloadFileFn   = download.File
-	UnzipFn          = download.Unzip
-	FindFirstByExtFn = download.FindFirstByExt
-	CopyFileFn       = download.CopyFile
-	matchIDPattern   = regexp.MustCompile(`(?i)g\d+(?:-[a-z0-9]+)+`)
-	playerDomainRE   = regexp.MustCompile(`(?i)(?:[?&]|^)domain=([^&#\s]+)`)
-	ErrDemoExpired   = errors.New("5E DEM 已过期，无法下载")
+	HTTPRequestFn = defaultHTTPRequest
+
+	// Transfer seams. They stay exported as compatibility hooks for tests and
+	// callers that must substitute the transport, but a nil function selects
+	// the built-in context-aware implementation so a workspace close can abort
+	// an in-flight transfer. Production never assigns them.
+	//
+	// UnzipFn receives the workspace context because extraction is the long
+	// phase that cannot be interrupted from outside; DownloadFileFn and
+	// CopyFileFn keep the legacy signature and are only re-checked after they
+	// return (their built-in implementations do honor the context).
+	DownloadFileFn   func(url string, targetPath string, emitProgress download.ProgressFunc) error
+	UnzipFn          func(ctx context.Context, zipPath string, destDir string) error
+	FindFirstByExtFn func(root string, ext string) (string, error)
+	CopyFileFn       func(src string, dst string) error
+
+	matchIDPattern = regexp.MustCompile(`(?i)g\d+(?:-[a-z0-9]+)+`)
+	playerDomainRE = regexp.MustCompile(`(?i)(?:[?&]|^)domain=([^&#\s]+)`)
+	ErrDemoExpired = errors.New("5E DEM 已过期，无法下载")
 )
 
 func defaultHTTPRequest(req *http.Request, timeout time.Duration) (*http.Response, error) {
@@ -102,7 +114,7 @@ func ListRecentMatches(playerName string, page int) ([]FiveEMatchItem, error) {
 	if page < 1 {
 		page = 1
 	}
-	return fetchRecentMatches(playerName, page)
+	return fetchRecentMatches(context.Background(), playerName, page)
 }
 
 // NormalizePlayerDomainInput extracts the 5E profile domain from share links.
@@ -127,7 +139,7 @@ func NormalizePlayerDomainInput(raw string) string {
 
 // FetchDemoURL resolves the download URL for a 5E match demo.
 func FetchDemoURL(matchID string) (string, error) {
-	return fetchDemoURL(matchID)
+	return fetchDemoURL(context.Background(), matchID)
 }
 
 // ExtractMatchID parses a raw 5E match ID string into its canonical form.
@@ -135,9 +147,24 @@ func ExtractMatchID(raw string) (string, error) {
 	return extractMatchID(raw)
 }
 
-// ImportDemo downloads and extracts a 5E demo into cacheRoot.
-// Returns the path to the stable .dem file on success.
+// ImportDemo is the compatibility entry point for callers that have no
+// workspace cancellation context. New app code uses ImportDemoContext.
 func ImportDemo(downloadMatchID, cacheRoot string, onProgress func(active bool, percent float64, indeterminate bool)) (string, error) {
+	return ImportDemoContext(context.Background(), downloadMatchID, cacheRoot, onProgress)
+}
+
+// ImportDemoContext downloads and extracts a 5E demo into cacheRoot.  The
+// stable .dem path is touched only by the final atomic copy commit.  Each task
+// owns one unique staging directory under cacheRoot and only removes that
+// directory; cancellation is checked before the download, between extraction
+// phases and at the final commit.
+func ImportDemoContext(ctx context.Context, downloadMatchID, cacheRoot string, onProgress func(active bool, percent float64, indeterminate bool)) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(cacheRoot, 0755); err != nil {
 		return "", fmt.Errorf("创建 5E DEM 缓存目录失败: %w", err)
 	}
@@ -148,7 +175,7 @@ func ImportDemo(downloadMatchID, cacheRoot string, onProgress func(active bool, 
 		return stableSourcePath, nil
 	}
 
-	demoURL, err := fetchDemoURL(downloadMatchID)
+	demoURL, err := fetchDemoURL(ctx, downloadMatchID)
 	if err != nil {
 		if errors.Is(err, ErrDemoExpired) {
 			return "", err
@@ -156,42 +183,88 @@ func ImportDemo(downloadMatchID, cacheRoot string, onProgress func(active bool, 
 		return "", fmt.Errorf("获取 5E DEM 下载地址失败: %w", err)
 	}
 
-	archiveName := safeArchiveName(demoURL, downloadMatchID)
-	archivePath := filepath.Join(cacheRoot, archiveName)
-	extractDir := filepath.Join(cacheRoot, "extract")
-	if err := os.RemoveAll(extractDir); err != nil {
-		return "", fmt.Errorf("清理 5E DEM 解压目录失败: %w", err)
+	stagingDir, err := os.MkdirTemp(cacheRoot, ".5e-import-*")
+	if err != nil {
+		return "", fmt.Errorf("创建 5E DEM 临时目录失败: %w", err)
 	}
+	defer os.RemoveAll(stagingDir)
+
+	archiveName := safeArchiveName(demoURL, downloadMatchID)
+	archivePath := filepath.Join(stagingDir, archiveName)
+	extractDir := filepath.Join(stagingDir, "extract")
 	if err := os.MkdirAll(extractDir, 0755); err != nil {
 		return "", fmt.Errorf("创建 5E DEM 解压目录失败: %w", err)
 	}
-	defer func() {
-		_ = os.RemoveAll(extractDir)
-		_ = os.Remove(archivePath)
-	}()
 
-	if err := DownloadFileFn(demoURL, archivePath, func(active bool, percent float64, indeterminate bool) {
-		if onProgress != nil {
-			onProgress(active, percent, indeterminate)
-		}
-	}); err != nil {
+	if err := downloadDemoArchive(ctx, demoURL, archivePath, onProgress); err != nil {
 		return "", fmt.Errorf("下载 5E DEM 失败: %w", err)
 	}
-	if err := UnzipFn(archivePath, extractDir); err != nil {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if err := unzipDemoArchive(ctx, archivePath, extractDir); err != nil {
 		return "", fmt.Errorf("解压 5E DEM 失败: %w", err)
 	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 
-	extractedDemPath, err := FindFirstByExtFn(extractDir, ".dem")
+	extractedDemPath, err := findDemoByExt(ctx, extractDir, ".dem")
 	if err != nil {
 		return "", fmt.Errorf("未在 5E DEM 压缩包中找到 .dem 文件: %w", err)
 	}
-
 	if extractedDemPath != stableSourcePath {
-		if err := CopyFileFn(extractedDemPath, stableSourcePath); err != nil {
+		if err := copyDemoFile(ctx, extractedDemPath, stableSourcePath); err != nil {
 			return "", fmt.Errorf("写入 5E DEM 缓存文件失败: %w", err)
 		}
 	}
 	return stableSourcePath, nil
+}
+
+func downloadDemoArchive(ctx context.Context, url, targetPath string, onProgress func(active bool, percent float64, indeterminate bool)) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if DownloadFileFn != nil {
+		if err := DownloadFileFn(url, targetPath, download.ProgressFunc(onProgress)); err != nil {
+			return err
+		}
+		return ctx.Err()
+	}
+	return download.FileWithContext(ctx, url, targetPath, download.ProgressFunc(onProgress))
+}
+
+func unzipDemoArchive(ctx context.Context, archivePath, destDir string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if UnzipFn != nil {
+		return UnzipFn(ctx, archivePath, destDir)
+	}
+	return download.UnzipWithContext(ctx, archivePath, destDir)
+}
+
+func findDemoByExt(ctx context.Context, root, ext string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if FindFirstByExtFn != nil {
+		return FindFirstByExtFn(root, ext)
+	}
+	return download.FindFirstByExt(root, ext)
+}
+
+func copyDemoFile(ctx context.Context, src, dst string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if CopyFileFn != nil {
+		if err := CopyFileFn(src, dst); err != nil {
+			return err
+		}
+		return ctx.Err()
+	}
+	return download.CopyFileAtomicWithContext(ctx, src, dst)
 }
 
 func safeArchiveName(rawURL, fallbackID string) string {
@@ -218,7 +291,7 @@ func safeArchiveName(rawURL, fallbackID string) string {
 	return archiveName
 }
 
-func fetchRecentMatches(playerName string, page int) ([]FiveEMatchItem, error) {
+func fetchRecentMatches(ctx context.Context, playerName string, page int) ([]FiveEMatchItem, error) {
 	endpoint, err := url.Parse(matchListURL)
 	if err != nil {
 		return nil, fmt.Errorf("构建 5E 战绩请求地址失败: %w", err)
@@ -236,6 +309,7 @@ func fetchRecentMatches(playerName string, page int) ([]FiveEMatchItem, error) {
 	if err != nil {
 		return nil, fmt.Errorf("创建 5E 战绩请求失败: %w", err)
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("Accept-Language", "zh-CN,zh-Hans;q=0.9")
 	req.Header.Set("Connection", "keep-alive")
@@ -305,12 +379,13 @@ func parseMatchList(raw []matchRaw) []FiveEMatchItem {
 	return result
 }
 
-func fetchDemoURL(matchID string) (string, error) {
+func fetchDemoURL(ctx context.Context, matchID string) (string, error) {
 	requestURL := strings.TrimRight(matchDetailBaseURL, "/") + "/" + url.PathEscape(strings.TrimSpace(matchID))
 	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("创建 5E 下载地址请求失败: %w", err)
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := HTTPRequestFn(req, 15*time.Second)

--- a/internal/fivee/client.go
+++ b/internal/fivee/client.go
@@ -142,12 +142,10 @@ func ImportDemo(downloadMatchID, cacheRoot string, onProgress func(active bool, 
 		return "", fmt.Errorf("创建 5E DEM 缓存目录失败: %w", err)
 	}
 	stableSourcePath := filepath.Join(cacheRoot, downloadMatchID+".dem")
-	if info, err := os.Stat(stableSourcePath); err == nil {
-		if info.Mode().IsRegular() && info.Size() > 0 {
-			return stableSourcePath, nil
-		}
-	} else if !os.IsNotExist(err) {
+	if valid, err := download.IsLikelyDemoFile(stableSourcePath); err != nil {
 		return "", fmt.Errorf("检查 5E DEM 缓存文件失败: %w", err)
+	} else if valid {
+		return stableSourcePath, nil
 	}
 
 	demoURL, err := fetchDemoURL(downloadMatchID)
@@ -158,11 +156,7 @@ func ImportDemo(downloadMatchID, cacheRoot string, onProgress func(active bool, 
 		return "", fmt.Errorf("获取 5E DEM 下载地址失败: %w", err)
 	}
 
-	archiveName := path.Base(demoURL)
-	archiveName = strings.TrimSpace(archiveName)
-	if archiveName == "" || archiveName == "." || archiveName == "/" {
-		archiveName = downloadMatchID + ".zip"
-	}
+	archiveName := safeArchiveName(demoURL, downloadMatchID)
 	archivePath := filepath.Join(cacheRoot, archiveName)
 	extractDir := filepath.Join(cacheRoot, "extract")
 	if err := os.RemoveAll(extractDir); err != nil {
@@ -198,6 +192,30 @@ func ImportDemo(downloadMatchID, cacheRoot string, onProgress func(active bool, 
 		}
 	}
 	return stableSourcePath, nil
+}
+
+func safeArchiveName(rawURL, fallbackID string) string {
+	archiveName := ""
+	if parsed, err := url.Parse(strings.TrimSpace(rawURL)); err == nil {
+		archivePath := strings.TrimSpace(parsed.Path)
+		if decoded, decodeErr := url.PathUnescape(archivePath); decodeErr == nil {
+			archivePath = decoded
+		}
+		archiveName = path.Base(archivePath)
+	}
+	archiveName = strings.TrimSpace(archiveName)
+	if archiveName == "" || archiveName == "." || archiveName == "/" || archiveName == `\` {
+		archiveName = strings.TrimSpace(fallbackID) + ".zip"
+	}
+	// URL query parameters are intentionally excluded above.  Keep the local
+	// name conservative for Windows and reject path traversal even if a server
+	// returns an unusual path segment.
+	archiveName = strings.NewReplacer("<", "_", ">", "_", ":", "_", `"`, "_", "/", "_", `\`, "_", "|", "_", "?", "_", "*", "_").Replace(archiveName)
+	archiveName = strings.Trim(archiveName, " .")
+	if archiveName == "" || strings.EqualFold(archiveName, strings.TrimSpace(fallbackID)+".dem") {
+		archiveName = strings.TrimSpace(fallbackID) + ".zip"
+	}
+	return archiveName
 }
 
 func fetchRecentMatches(playerName string, page int) ([]FiveEMatchItem, error) {

--- a/internal/fivee/client_test.go
+++ b/internal/fivee/client_test.go
@@ -226,6 +226,21 @@ func TestNormalizePlayerDomainInput(t *testing.T) {
 	}
 }
 
+func TestSafeArchiveNameStripsURLQueryAndUnsafeCharacters(t *testing.T) {
+	got := safeArchiveName("https://example.com/path/demo.zip?signature=secret&expires=123", "g161-20260427162329954189731")
+	if got != "demo.zip" {
+		t.Fatalf("safeArchiveName() = %q, want %q", got, "demo.zip")
+	}
+
+	got = safeArchiveName("https://example.com/download?name=demo.zip", "g161-20260427162329954189731")
+	if strings.ContainsAny(got, `?\/:*<>|"`) {
+		t.Fatalf("safeArchiveName() returned unsafe name %q", got)
+	}
+	if got == "" {
+		t.Fatal("safeArchiveName() returned empty name")
+	}
+}
+
 func TestImportDemo_ExpiredDemoURL(t *testing.T) {
 	oldReq := HTTPRequestFn
 	oldDownload := DownloadFileFn
@@ -278,7 +293,7 @@ func TestImportDemo_ReuseCachedDemoWithoutRedownload(t *testing.T) {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return err
 		}
-		return os.WriteFile(filepath.Join(destDir, "inner.dem"), []byte("fivee-dem"), 0644)
+		return os.WriteFile(filepath.Join(destDir, "inner.dem"), []byte("PBDEMS2\x00fivee-dem"), 0644)
 	}
 	FindFirstByExtFn = download.FindFirstByExt
 	CopyFileFn = download.CopyFile
@@ -331,8 +346,8 @@ func TestImportDemo_ReuseCachedDemoWithoutRedownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read managed demo failed: %v", err)
 	}
-	if string(content) != "fivee-dem" {
-		t.Fatalf("managed demo content = %q, want %q", string(content), "fivee-dem")
+	if string(content) != "PBDEMS2\x00fivee-dem" {
+		t.Fatalf("managed demo content = %q, want %q", string(content), "PBDEMS2\\x00fivee-dem")
 	}
 }
 

--- a/internal/fivee/client_test.go
+++ b/internal/fivee/client_test.go
@@ -3,6 +3,7 @@ package fivee
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"io"
 	"math"
 	"net/http"
@@ -288,7 +289,7 @@ func TestImportDemo_ReuseCachedDemoWithoutRedownload(t *testing.T) {
 		downloadCalls++
 		return os.WriteFile(targetPath, []byte("zip"), 0644)
 	}
-	UnzipFn = func(archivePath string, destDir string) error {
+	UnzipFn = func(ctx context.Context, archivePath string, destDir string) error {
 		unzipCalls++
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return err

--- a/internal/wanmei/client.go
+++ b/internal/wanmei/client.go
@@ -2,6 +2,7 @@ package wanmei
 
 import (
 	"bytes"
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/md5"
@@ -111,10 +112,20 @@ const (
 var (
 	HTTPRequestFn      = defaultHTTPRequest
 	OSSResolveHTTPDoFn = defaultOSSResolveHTTPDo
-	DownloadFileFn     = download.File
-	UnzipFn            = download.Unzip
-	FindFirstByExtFn   = download.FindFirstByExt
-	CopyFileFn         = download.CopyFile
+
+	// Transfer seams. They stay exported as compatibility hooks for tests and
+	// callers that must substitute the transport, but a nil function selects
+	// the built-in context-aware implementation so a workspace close can abort
+	// an in-flight transfer. Production never assigns them.
+	//
+	// UnzipFn receives the workspace context because extraction is the long
+	// phase that cannot be interrupted from outside; DownloadFileFn and
+	// CopyFileFn keep the legacy signature and are only re-checked after they
+	// return (their built-in implementations do honor the context).
+	DownloadFileFn   func(url string, targetPath string, emitProgress download.ProgressFunc) error
+	UnzipFn          func(ctx context.Context, zipPath string, destDir string) error
+	FindFirstByExtFn func(root string, ext string) (string, error)
+	CopyFileFn       func(src string, dst string) error
 )
 
 func defaultOSSResolveHTTPDo(req *http.Request, timeout time.Duration) (*http.Response, error) {
@@ -145,7 +156,7 @@ func ListRecentMatches(page int) (*WanmeiMatchListResult, error) {
 
 	result := &WanmeiMatchListResult{Matches: make([]WanmeiMatchItem, 0)}
 
-	loginInfo, status, err := fetchLocalLoginInfo()
+	loginInfo, status, err := fetchLocalLoginInfoContext(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +167,7 @@ func ListRecentMatches(page int) (*WanmeiMatchListResult, error) {
 
 	result.Nickname = loginInfo.Nickname
 	result.SteamID = loginInfo.SteamID
-	matches, err := fetchRecentMatches(loginInfo.Token, loginInfo.SteamID, page)
+	matches, err := fetchRecentMatchesContext(context.Background(), loginInfo.Token, loginInfo.SteamID, page)
 	if err != nil {
 		return nil, err
 	}
@@ -164,9 +175,24 @@ func ListRecentMatches(page int) (*WanmeiMatchListResult, error) {
 	return result, nil
 }
 
-// ImportDemo downloads and extracts a Wanmei demo into cacheRoot.
-// Returns the path to the stable .dem file on success.
+// ImportDemo is the compatibility entry point for callers that have no
+// workspace cancellation context. New app code uses ImportDemoContext.
 func ImportDemo(downloadMatchID, cacheRoot string, onProgress func(active bool, percent float64, indeterminate bool)) (string, error) {
+	return ImportDemoContext(context.Background(), downloadMatchID, cacheRoot, onProgress)
+}
+
+// ImportDemoContext downloads and extracts a Wanmei demo into cacheRoot.  The
+// stable .dem path is touched only by the final atomic copy commit.  Each task
+// owns one unique staging directory under cacheRoot and only removes that
+// directory; cancellation is checked before the download, between extraction
+// phases and at the final commit.
+func ImportDemoContext(ctx context.Context, downloadMatchID, cacheRoot string, onProgress func(active bool, percent float64, indeterminate bool)) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(cacheRoot, 0755); err != nil {
 		return "", fmt.Errorf("创建完美 DEM 缓存目录失败: %w", err)
 	}
@@ -177,20 +203,7 @@ func ImportDemo(downloadMatchID, cacheRoot string, onProgress func(active bool, 
 		return stableSourcePath, nil
 	}
 
-	archivePath := filepath.Join(cacheRoot, downloadMatchID+"_0.zip")
-	extractDir := filepath.Join(cacheRoot, "extract")
-	if err := os.RemoveAll(extractDir); err != nil {
-		return "", fmt.Errorf("清理完美 DEM 解压目录失败: %w", err)
-	}
-	if err := os.MkdirAll(extractDir, 0755); err != nil {
-		return "", fmt.Errorf("创建完美 DEM 解压目录失败: %w", err)
-	}
-	defer func() {
-		_ = os.RemoveAll(extractDir)
-		_ = os.Remove(archivePath)
-	}()
-
-	loginInfo, status, err := fetchLocalLoginInfo()
+	loginInfo, status, err := fetchLocalLoginInfoContext(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -198,45 +211,103 @@ func ImportDemo(downloadMatchID, cacheRoot string, onProgress func(active bool, 
 		return "", fmt.Errorf("完美客户端未登录，无法下载 DEM")
 	}
 
-	ipAddr, ipErr := fetchPublicIPv4(publicIPAPI, time.Duration(defaultTimeout)*time.Second)
-	if ipErr != nil {
-		return "", fmt.Errorf("获取公网 IP 失败: %w", ipErr)
+	ipAddr, err := fetchPublicIPv4Context(ctx, publicIPAPI, time.Duration(defaultTimeout)*time.Second)
+	if err != nil {
+		return "", fmt.Errorf("获取公网 IP 失败: %w", err)
 	}
 
 	signedURL := buildSignedDemoURL(downloadMatchID, "0", loginInfo.Token)
-
 	pwaHeaders, err := buildPWAHeaders(loginInfo.SteamID, ipAddr, loginInfo.ServerTime)
 	if err != nil {
 		return "", fmt.Errorf("构建 PWA 请求头失败: %w", err)
 	}
 
-	ossURL, err := resolveOSSURL(signedURL, pwaHeaders, time.Duration(defaultTimeout)*time.Second)
+	ossURL, err := resolveOSSURLContext(ctx, signedURL, pwaHeaders, time.Duration(defaultTimeout)*time.Second)
 	if err != nil {
 		return "", fmt.Errorf("解析 DEM 下载地址失败: %w", err)
 	}
 
-	if err := DownloadFileFn(ossURL, archivePath, func(active bool, percent float64, indeterminate bool) {
-		if onProgress != nil {
-			onProgress(active, percent, indeterminate)
-		}
-	}); err != nil {
-		return "", fmt.Errorf("下载完美 DEM 失败: %w", err)
+	stagingDir, err := os.MkdirTemp(cacheRoot, ".wanmei-import-*")
+	if err != nil {
+		return "", fmt.Errorf("创建完美 DEM 临时目录失败: %w", err)
 	}
-	if err := UnzipFn(archivePath, extractDir); err != nil {
-		return "", fmt.Errorf("解压完美 DEM 失败: %w", err)
+	defer os.RemoveAll(stagingDir)
+
+	archivePath := filepath.Join(stagingDir, downloadMatchID+"_0.zip")
+	extractDir := filepath.Join(stagingDir, "extract")
+	if err := os.MkdirAll(extractDir, 0755); err != nil {
+		return "", fmt.Errorf("创建完美 DEM 解压目录失败: %w", err)
 	}
 
-	extractedDemPath, err := FindFirstByExtFn(extractDir, ".dem")
+	if err := downloadDemoArchive(ctx, ossURL, archivePath, onProgress); err != nil {
+		return "", fmt.Errorf("下载完美 DEM 失败: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if err := unzipDemoArchive(ctx, archivePath, extractDir); err != nil {
+		return "", fmt.Errorf("解压完美 DEM 失败: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	extractedDemPath, err := findDemoByExt(ctx, extractDir, ".dem")
 	if err != nil {
 		return "", fmt.Errorf("未在完美 DEM 压缩包中找到 .dem 文件: %w", err)
 	}
-
 	if extractedDemPath != stableSourcePath {
-		if err := CopyFileFn(extractedDemPath, stableSourcePath); err != nil {
+		if err := copyDemoFile(ctx, extractedDemPath, stableSourcePath); err != nil {
 			return "", fmt.Errorf("写入完美 DEM 缓存文件失败: %w", err)
 		}
 	}
 	return stableSourcePath, nil
+}
+
+func downloadDemoArchive(ctx context.Context, url, targetPath string, onProgress func(active bool, percent float64, indeterminate bool)) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if DownloadFileFn != nil {
+		if err := DownloadFileFn(url, targetPath, download.ProgressFunc(onProgress)); err != nil {
+			return err
+		}
+		return ctx.Err()
+	}
+	return download.FileWithContext(ctx, url, targetPath, download.ProgressFunc(onProgress))
+}
+
+func unzipDemoArchive(ctx context.Context, archivePath, destDir string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if UnzipFn != nil {
+		return UnzipFn(ctx, archivePath, destDir)
+	}
+	return download.UnzipWithContext(ctx, archivePath, destDir)
+}
+
+func findDemoByExt(ctx context.Context, root, ext string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if FindFirstByExtFn != nil {
+		return FindFirstByExtFn(root, ext)
+	}
+	return download.FindFirstByExt(root, ext)
+}
+
+func copyDemoFile(ctx context.Context, src, dst string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if CopyFileFn != nil {
+		if err := CopyFileFn(src, dst); err != nil {
+			return err
+		}
+		return ctx.Err()
+	}
+	return download.CopyFileAtomicWithContext(ctx, src, dst)
 }
 
 // ExtractNumericMatchID parses a raw Wanmei match ID string into its numeric form.
@@ -271,10 +342,15 @@ func ExtractNumericMatchID(raw string) (string, error) {
 }
 
 func fetchLocalLoginInfo() (*localLoginInfo, ClientStatus, error) {
+	return fetchLocalLoginInfoContext(context.Background())
+}
+
+func fetchLocalLoginInfoContext(ctx context.Context) (*localLoginInfo, ClientStatus, error) {
 	req, err := http.NewRequest(http.MethodGet, localLoginURL, nil)
 	if err != nil {
 		return nil, ClientNotRunning, fmt.Errorf("创建完美本地登录请求失败: %w", err)
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Origin", allowedOrigin)
 	req.Header.Set("Referer", allowedOrigin+"/")
 
@@ -322,6 +398,10 @@ func fetchLocalLoginInfo() (*localLoginInfo, ClientStatus, error) {
 }
 
 func fetchRecentMatches(token string, steamID string, page int) ([]WanmeiMatchItem, error) {
+	return fetchRecentMatchesContext(context.Background(), token, steamID, page)
+}
+
+func fetchRecentMatchesContext(ctx context.Context, token string, steamID string, page int) ([]WanmeiMatchItem, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -349,6 +429,7 @@ func fetchRecentMatches(token string, steamID string, page int) ([]WanmeiMatchIt
 	if err != nil {
 		return nil, fmt.Errorf("创建完美战绩请求失败: %w", err)
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("token", token)
@@ -582,11 +663,16 @@ func parseDecodedToken(decoded string) (string, string, string, error) {
 }
 
 func fetchPublicIPv4(ipAPI string, timeout time.Duration) (string, error) {
+	return fetchPublicIPv4Context(context.Background(), ipAPI, timeout)
+}
+
+func fetchPublicIPv4Context(ctx context.Context, ipAPI string, timeout time.Duration) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, ipAPI, nil)
 	if err != nil {
 		return "", fmt.Errorf("创建 IP 查询请求失败: %w", err)
 	}
 
+	req = req.WithContext(ctx)
 	resp, err := HTTPRequestFn(req, timeout)
 	if err != nil {
 		return "", fmt.Errorf("请求公网 IP 失败: %w", err)
@@ -651,6 +737,10 @@ func pkcs7Pad(data []byte, blockSize int) []byte {
 }
 
 func resolveOSSURL(signedURL string, headers map[string]string, timeout time.Duration) (string, error) {
+	return resolveOSSURLContext(context.Background(), signedURL, headers, timeout)
+}
+
+func resolveOSSURLContext(ctx context.Context, signedURL string, headers map[string]string, timeout time.Duration) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, signedURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("创建签名请求失败: %w", err)
@@ -658,6 +748,7 @@ func resolveOSSURL(signedURL string, headers map[string]string, timeout time.Dur
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := OSSResolveHTTPDoFn(req, timeout)
 	if err != nil {

--- a/internal/wanmei/client.go
+++ b/internal/wanmei/client.go
@@ -94,11 +94,11 @@ type matchRaw struct {
 }
 
 const (
-	localLoginURL       = "http://127.0.0.1:55555/"
-	allowedOrigin       = "https://esports.wanmei.com"
-	matchListURL        = "https://api.wmpvp.com/api/csgo/home/match/list"
-	matchPageSize       = 11
-	ProgressPrefix      = "wanmei_import_"
+	localLoginURL  = "http://127.0.0.1:55555/"
+	allowedOrigin  = "https://esports.wanmei.com"
+	matchListURL   = "https://api.wmpvp.com/api/csgo/home/match/list"
+	matchPageSize  = 11
+	ProgressPrefix = "wanmei_import_"
 
 	demoAppID      = "20000"
 	demoSecret     = "969c1bcfdc527c319157cc48f83b1d106ebdeca3e8d9763f1ae6b88dde9b3ea9"
@@ -171,12 +171,10 @@ func ImportDemo(downloadMatchID, cacheRoot string, onProgress func(active bool, 
 		return "", fmt.Errorf("创建完美 DEM 缓存目录失败: %w", err)
 	}
 	stableSourcePath := filepath.Join(cacheRoot, downloadMatchID+".dem")
-	if info, err := os.Stat(stableSourcePath); err == nil {
-		if info.Mode().IsRegular() && info.Size() > 0 {
-			return stableSourcePath, nil
-		}
-	} else if !os.IsNotExist(err) {
+	if valid, err := download.IsLikelyDemoFile(stableSourcePath); err != nil {
 		return "", fmt.Errorf("检查完美 DEM 缓存文件失败: %w", err)
+	} else if valid {
+		return stableSourcePath, nil
 	}
 
 	archivePath := filepath.Join(cacheRoot, downloadMatchID+"_0.zip")

--- a/internal/wanmei/client_test.go
+++ b/internal/wanmei/client_test.go
@@ -236,7 +236,7 @@ func TestImportDemo_ReuseCachedDemoWithoutRedownload(t *testing.T) {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return err
 		}
-		content := fmt.Sprintf("dem-%d", unzipCalls)
+		content := fmt.Sprintf("PBDEMS2\x00dem-%d", unzipCalls)
 		return os.WriteFile(filepath.Join(destDir, fmt.Sprintf("inner-%d.dem", unzipCalls)), []byte(content), 0644)
 	}
 	FindFirstByExtFn = download.FindFirstByExt
@@ -288,8 +288,8 @@ func TestImportDemo_ReuseCachedDemoWithoutRedownload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read managed demo failed: %v", err)
 	}
-	if string(content) != "dem-1" {
-		t.Fatalf("managed demo content = %q, want %q", string(content), "dem-1")
+	if string(content) != "PBDEMS2\x00dem-1" {
+		t.Fatalf("managed demo content = %q, want %q", string(content), "PBDEMS2\\x00dem-1")
 	}
 }
 

--- a/internal/wanmei/client_test.go
+++ b/internal/wanmei/client_test.go
@@ -1,6 +1,7 @@
 package wanmei
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -231,7 +232,7 @@ func TestImportDemo_ReuseCachedDemoWithoutRedownload(t *testing.T) {
 		}
 		return os.WriteFile(targetPath, []byte("zip"), 0644)
 	}
-	UnzipFn = func(archivePath string, destDir string) error {
+	UnzipFn = func(ctx context.Context, archivePath string, destDir string) error {
 		unzipCalls++
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return err
@@ -330,7 +331,7 @@ func TestImportDemo_EmptyCachedDemoTriggersRedownload(t *testing.T) {
 		downloadCalls++
 		return os.WriteFile(targetPath, []byte("zip"), 0644)
 	}
-	UnzipFn = func(archivePath string, destDir string) error {
+	UnzipFn = func(ctx context.Context, archivePath string, destDir string) error {
 		unzipCalls++
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return err


### PR DESCRIPTION
## Summary
Step 03 (B3/B4/B6) — make component installs and demo cache commits recoverable, and coordinate concurrent imports of the same match.

### Install transaction (B6)
- `download.ReplaceDirWithContents` prepares a unique same-volume staging, moves the old target to a unique backup, commits with rename, and restores the backup when the commit fails.
- A failed copy/backup never deletes the old target; a failed recovery keeps staging and backup and returns the primary+recovery errors; a post-commit backup cleanup failure is a warning exposed by `ReplaceDirWithContentsWithReport`.
- Component-specific checks stay in `envsetup` and run before the commit.

### Atomic demo cache commit (B3)
- `download.CopyFile` writes a same-directory temp file, checks Copy/Close, then commits with rename and restores the previous cache if the replacement fails.
- `IsLikelyDemoFile` provides the deliberately limited file-stamp validation for legacy caches (not an integrity proof).

### Same-match import coordination (B4)
- `app/import_coordinator.go` shares one download/extract/commit per `(platform, normalized matchID)`; different keys still run in parallel.
- Shared tasks run on the workspace lifecycle context and hold file-use admission until the real task exits; waiter cancellation exits only that waiter, failures are not cached, and progress is emitted only by the real task.
- Extraction is cancellable via `download.UnzipWithContext` (checks ctx per entry and per copy chunk); each real task uses its own staging directory.

### Review fixes
- `CopyFile` rejects an existing directory/non-regular target before moving it aside; previously the directory was moved to a hidden backup and replaced by the committed file.
- The FFmpeg archive layout (`bin/ffmpeg.exe`) is validated before the directory transaction, so `release/tools/ffmpeg.exe`-style archives no longer destroy a working `<dataDir>/ffmpeg/bin/ffmpeg.exe`.

## Tests
- `internal/download`: install transaction fault injection (copy/backup/commit/restore/cleanup), atomic-copy failure paths, directory-target rejection, `UnzipWithContext` cancellation
- `internal/envsetup`: validate-before-commit regressions for HLAE/FFmpeg, FFmpeg layout cases (nested, flat, valid `bin/`)
- `internal/app`: coordinator dedup/parallel/waiter-cancel/retry/panic/workspace-close plus platform import lifecycle tests (local httptest, no real accounts)

## Validation
- `go test ./...`
- `go test -race ./internal/app ./internal/fivee ./internal/wanmei ./internal/download ./internal/envsetup`
- `go vet ./...`
- `gofmt -l`, `git diff --check`

## Not verified (needs Windows)
- Windows file-in-use behavior for the backup/commit renames and for `CopyFile` replacement
- Real platform downloads/account flows and real component archives
